### PR TITLE
@shopify/theme-cart broken "this" refs

### DIFF
--- a/packages/theme-cart/cart.cjs.js
+++ b/packages/theme-cart/cart.cjs.js
@@ -36,7 +36,7 @@ function getCart() {
 }
 
 function updateNote(note) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/update.js',
     dataType: 'json',
     data: {
@@ -46,7 +46,7 @@ function updateNote(note) {
 }
 
 function addItem(id, quantity) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data: {
@@ -57,7 +57,7 @@ function addItem(id, quantity) {
 }
 
 function addItemFromForm(data) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data: data
@@ -65,7 +65,7 @@ function addItemFromForm(data) {
 }
 
 function removeItem(id) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/change.js',
     dataType: 'json',
     data: {
@@ -86,7 +86,7 @@ function changeItem(id, quantity) {
     }
   };
 
-  return this._promiseChange(requestSettings);
+  return _promiseChange(requestSettings);
 }
 
 function saveLocalState(state) {
@@ -115,8 +115,6 @@ function cookiesEnabled() {
 }
 
 function _promiseChange(parameters) {
-  var _this = this;
-
   var promiseRequest = _jquery2.default.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
@@ -129,11 +127,11 @@ function _promiseChange(parameters) {
   // cart object then get one before proceeding.
   .then(function (state) {
     if (typeof state.token === 'undefined') {
-      return _this.getCart();
+      return getCart();
     } else {
       return state;
     }
-  }).then(this.saveLocalState);
+  }).then(saveLocalState);
 }
 
 function _isLocalStorageSupported() {

--- a/packages/theme-cart/cart.es5.js
+++ b/packages/theme-cart/cart.es5.js
@@ -14,7 +14,7 @@ export function getCart() {
 }
 
 export function updateNote(note) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/update.js',
     dataType: 'json',
     data: {
@@ -24,7 +24,7 @@ export function updateNote(note) {
 }
 
 export function addItem(id, quantity) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data: {
@@ -35,7 +35,7 @@ export function addItem(id, quantity) {
 }
 
 export function addItemFromForm(data) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data: data
@@ -43,7 +43,7 @@ export function addItemFromForm(data) {
 }
 
 export function removeItem(id) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/change.js',
     dataType: 'json',
     data: {
@@ -64,7 +64,7 @@ export function changeItem(id, quantity) {
     }
   };
 
-  return this._promiseChange(requestSettings);
+  return _promiseChange(requestSettings);
 }
 
 export function saveLocalState(state) {
@@ -93,8 +93,6 @@ export function cookiesEnabled() {
 }
 
 function _promiseChange(parameters) {
-  var _this = this;
-
   var promiseRequest = $.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
@@ -107,11 +105,11 @@ function _promiseChange(parameters) {
   // cart object then get one before proceeding.
   .then(function (state) {
     if (typeof state.token === 'undefined') {
-      return _this.getCart();
+      return getCart();
     } else {
       return state;
     }
-  }).then(this.saveLocalState);
+  }).then(saveLocalState);
 }
 
 function _isLocalStorageSupported() {

--- a/packages/theme-cart/src/cart.js
+++ b/packages/theme-cart/src/cart.js
@@ -14,7 +14,7 @@ export function getCart() {
 }
 
 export function updateNote(note) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/update.js',
     dataType: 'json',
     data: {
@@ -24,7 +24,7 @@ export function updateNote(note) {
 }
 
 export function addItem(id, quantity) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data: {
@@ -35,7 +35,7 @@ export function addItem(id, quantity) {
 }
 
 export function addItemFromForm(data) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/add.js',
     dataType: 'json',
     data,
@@ -43,7 +43,7 @@ export function addItemFromForm(data) {
 }
 
 export function removeItem(id) {
-  return this._promiseChange({
+  return _promiseChange({
     url: '/cart/change.js',
     dataType: 'json',
     data: {
@@ -64,7 +64,7 @@ export function changeItem(id, quantity) {
     },
   };
 
-  return this._promiseChange(requestSettings);
+  return _promiseChange(requestSettings);
 }
 
 export function saveLocalState(state) {
@@ -107,13 +107,13 @@ function _promiseChange(parameters) {
       .then(
         (state) => {
           if (typeof state.token === 'undefined') {
-            return this.getCart();
+            return getCart();
           } else {
             return state;
           }
         }
       )
-      .then(this.saveLocalState)
+      .then(saveLocalState)
   );
 }
 


### PR DESCRIPTION
Fixes #5.

importing and using theme-cart currently always results in `Uncaught TypeError: this._promiseChange is not a function` due to strange `this` references.  Too me looks like it was taken out of another file, and not properly fixed. 

A couple greps indicated that the only export function being called in slate is `cookiesEnabled` which doesn't rely on the `_promiseChange` util, likely why the issue has not been noticed yet.

PR removes those `this` calls.