### PR TITLE
Fix slate.utils reference

### DIFF
--- a/packages/theme-variants/src/variants.js
+++ b/packages/theme-variants/src/variants.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import { compact } from "lodash";
 
 /**
  * Variant Selection scripts
@@ -65,7 +66,7 @@ export default class Variants {
     );
 
     // remove any unchecked input values if using radio buttons or checkboxes
-    currentOptions = slate.utils.compact(currentOptions);
+    currentOptions = compact(currentOptions);
 
     return currentOptions;
   }


### PR DESCRIPTION
### WHAT are you trying to accomplish with this PR?
While working on starter theme product, an error inside `product.js` was referring to `theme-scripts/theme-variants`. Inside this theme-variants file, there was code stating `slate.utils` which does not exist anymore.

### WHY are you choosing this approach?
Since theme-utils does not exist, we used `lodash` "compact" built-in method to fix the issue.

### HOW is this accomplished?
Removed `slate.utils` line and replaced by `lodash` built-in function.
