### PR TITLE
fix incorrect offline condition

### DIFF
--- a/packages/theme-cart/cart.cjs.js
+++ b/packages/theme-cart/cart.cjs.js
@@ -120,7 +120,7 @@ function _promiseChange(parameters) {
   var promiseRequest = _jquery2.default.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !theme.isOnline) {
+  if (navigator && !navigator.isOnline) {
     promiseRequest = _jquery2.default.Deferred().reject();
   }
 

--- a/packages/theme-cart/cart.cjs.js
+++ b/packages/theme-cart/cart.cjs.js
@@ -120,7 +120,7 @@ function _promiseChange(parameters) {
   var promiseRequest = _jquery2.default.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !navigator.isOnline) {
+  if (navigator && !navigator.onLine) {
     promiseRequest = _jquery2.default.Deferred().reject();
   }
 

--- a/packages/theme-cart/cart.es5.js
+++ b/packages/theme-cart/cart.es5.js
@@ -98,7 +98,7 @@ function _promiseChange(parameters) {
   var promiseRequest = $.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !theme.isOnline) {
+  if (navigator && !navigator.isOnline) {
     promiseRequest = $.Deferred().reject();
   }
 

--- a/packages/theme-cart/cart.es5.js
+++ b/packages/theme-cart/cart.es5.js
@@ -98,7 +98,7 @@ function _promiseChange(parameters) {
   var promiseRequest = $.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !navigator.isOnline) {
+  if (navigator && !navigator.onLine) {
     promiseRequest = $.Deferred().reject();
   }
 

--- a/packages/theme-cart/src/cart.js
+++ b/packages/theme-cart/src/cart.js
@@ -96,7 +96,7 @@ function _promiseChange(parameters) {
   let promiseRequest = $.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !theme.isOnline) {
+  if (navigator && !navigator.isOnline) {
     promiseRequest = $.Deferred().reject();
   }
 

--- a/packages/theme-cart/src/cart.js
+++ b/packages/theme-cart/src/cart.js
@@ -96,7 +96,7 @@ function _promiseChange(parameters) {
   let promiseRequest = $.ajax(parameters);
 
   // If offline, provide a rejected promise so that an error is thrown.
-  if (navigator && !navigator.isOnline) {
+  if (navigator && !navigator.onLine) {
     promiseRequest = $.Deferred().reject();
   }
 


### PR DESCRIPTION
The `_promiseChange` function, which is used in most cart AJAX helpers, includes a faulty check for `theme.isOnline`. If that property is not set, this rejects all promises and therefore breaks all AJAX calls. I believe this was supposed to be `navigator.onLine`.