### PR TITLE
Add private key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "theme-scripts",
+  "private": true,
   "version": "1.0.0-alpha.0",
   "description":
     "A collection of helpful script libraries that help you make better Shopify themes.",


### PR DESCRIPTION
Fixes error when trying to install dependencies. We add this to prevent accidental publication since we don't want the root to be consumed as a package.

![image](https://user-images.githubusercontent.com/991693/40844578-57502322-6582-11e8-8a60-40c533b5c1e7.png)

cc @t-kelly 