### PR TITLE
Check and return early if link.hash is empty or just '#'

### DIFF
--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -48,18 +48,26 @@ export function focusHash() {
  * When an in-page (url w/hash) link is clicked, focus the appropriate element
  */
 export function bindInPageLinks() {
-  var links = document.querySelectorAll('a[href^="#"]');
+  var links = Array.prototype.slice.call(
+    document.querySelectorAll('a[href^="#"]')
+  );
 
-  links.forEach(function(link) {
+  return links.filter(function(link) {
+    if (link.hash === '#' || link.hash === '') {
+      return false;
+    }
+
     var element = document.querySelector(link.hash);
 
     if (!element) {
-      return;
+      return false;
     }
 
     link.addEventListener('click', function() {
       pageLinkFocus(element);
     });
+
+    return true;
   });
 }
 

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -113,11 +113,21 @@ describe('focusHash()', () => {
 describe('bindInPageLinks()', () => {
   beforeEach(() => {
     document.body.innerHTML =
-      '<a id="link" href="#title"></a>' + '<h1 id="title">Title</h1>';
+      '<a id="link" href="#title"></a>' +
+      '<a id="invalidLink1" href="#"></a>' +
+      '<a id="invalidLink2" href="/otherlink"></a>' +
+      '<h1 id="title">Title</h1>';
   });
 
   test('is a function exported by theme-a11y.js', () => {
     expect(typeof bindInPageLinks).toBe('function');
+  });
+
+  test('returns array of link elements that were binded', () => {
+    const links = bindInPageLinks();
+
+    expect(Array.isArray(links)).toBeTruthy;
+    expect(links.length).toBe(1);
   });
 
   test("adds an event handler that focuses the element referred to in an <a> element w/ a href='#...' when it is clicked", () => {
@@ -127,6 +137,7 @@ describe('bindInPageLinks()', () => {
     bindInPageLinks();
 
     link.click();
+
     expect(document.activeElement).toBe(title);
   });
 });


### PR DESCRIPTION
`querySelector()` throws an error if passed an empty string or `'#'` value.