### PR TITLE
Sections Typo Fix

### DIFF
--- a/packages/theme-sections/theme-sections.js
+++ b/packages/theme-sections/theme-sections.js
@@ -215,7 +215,7 @@ if (window.Shopify.designMode) {
   document.addEventListener('shopify:section:load', function(event) {
     var id = event.detail.sectionId;
     var container = event.target.querySelector(
-      '[' + SECTION_ID_ATTR + '="' + id + '}"]'
+      '[' + SECTION_ID_ATTR + '="' + id + '"]'
     );
     var type = container.getAttribute(SECTION_TYPE_ATTR);
 


### PR DESCRIPTION
Typo fix during theme editor section reload. Noticed this when creating some custom event handler code for some new sections. That right curly brace just got squished in there by accident it seems. 