### PR TITLE
Fix load theme sections

### DIFF
--- a/packages/theme-sections/section.js
+++ b/packages/theme-sections/section.js
@@ -8,12 +8,14 @@ export default function Section(container, properties) {
   assign(this, validatePropertiesObject(properties));
 
   if (window.Shopify.designMode) {
+    this._onLoad = this._onLoad.bind(this);
     this._onUnload = this._onUnload.bind(this);
     this._onSelect = this._onSelect.bind(this);
     this._onDeselect = this._onDeselect.bind(this);
     this._onBlockSelect = this._onBlockSelect.bind(this);
     this._onBlockDeselect = this._onBlockDeselect.bind(this);
 
+    document.addEventListener('shopify:section:load', this._onLoad);
     document.addEventListener('shopify:section:unload', this._onUnload);
     document.addEventListener('shopify:section:select', this._onSelect);
     document.addEventListener('shopify:section:deselect', this._onDeselect);
@@ -60,6 +62,10 @@ Section.prototype = {
     if (typeof extension.init === 'function') {
       extension.init.apply(this);
     }
+  },
+
+  _onLoad: function _onLoad(event) {
+    this.id === event.detail.sectionId && this.onLoad(event.detail.load);
   },
 
   _onUnload: function _onUnload(event) {

--- a/packages/theme-sections/theme-sections.js
+++ b/packages/theme-sections/theme-sections.js
@@ -212,13 +212,16 @@ function normalizeContainers(containers) {
 }
 
 if (window.Shopify.designMode) {
-  document.addEventListener('shopify:section:load', function(event) {
-    var id = event.detail.sectionId;
-    var container = event.target.querySelector(
-      '[' + SECTION_ID_ATTR + '="' + id + '}"]'
-    );
-    var type = container.getAttribute(SECTION_TYPE_ATTR);
+  document.addEventListener('shopify:section:load', event => {
+    const container = event.target;
+    const containerDataset = container.dataset;
 
+    // Hack solution - pulling the first data-attribute since the identifier is unknown
+    const sectionData = JSON.parse(
+      containerDataset[Object.keys(containerDataset)[0]]
+    );
+
+    const type = sectionData.type;
     load(type, container);
   });
 }


### PR DESCRIPTION
Fixes a Theme Editor issue where JS errors were triggered and Section JS failed to reload after modifying section setting, adding a block, reordering, or any other event that triggers `shopify:section:load`.

- Fixed null container and type values with a new method to get the section type inside the Theme Editor #34
- Added a new `_onLoad` method to trigger the `onLoad` of Section js when the `shopify:section:load` event is fired #37 

_This approach should replace the open PR #36_