### PR TITLE
Fix theme-section.js breaking on section reload

### DIFF
--- a/packages/theme-sections/section.js
+++ b/packages/theme-sections/section.js
@@ -5,87 +5,29 @@ export default function Section(container, properties) {
   this.id = container.getAttribute(SECTION_ID_ATTR);
   this.extensions = [];
 
-  assign(this, validatePropertiesObject(properties));
-
-  if (window.Shopify.designMode) {
-    this._onUnload = this._onUnload.bind(this);
-    this._onSelect = this._onSelect.bind(this);
-    this._onDeselect = this._onDeselect.bind(this);
-    this._onBlockSelect = this._onBlockSelect.bind(this);
-    this._onBlockDeselect = this._onBlockDeselect.bind(this);
-
-    document.addEventListener('shopify:section:unload', this._onUnload);
-    document.addEventListener('shopify:section:select', this._onSelect);
-    document.addEventListener('shopify:section:deselect', this._onDeselect);
-    document.addEventListener('shopify:block:select', this._onBlockSelect);
-    document.addEventListener('shopify:block:deselect', this._onBlockDeselect);
-  }
+  Object.assign(this, validatePropertiesObject(properties));
 
   this.onLoad();
 }
 
 Section.prototype = {
-  onLoad: function onLoad() {},
-  onUnload: function onUnload() {},
-  onSelect: function onSelect() {},
-  onDeselect: function onDeselect() {},
-  onBlockSelect: function onBlockSelect() {},
-  onBlockDeselect: function onBlockDeselect() {},
-
-  unload: function() {
-    this.onUnload();
-
-    if (window.Shopify.designMode) {
-      document.removeEventListener('shopify:section:unload', this._onUnload);
-      document.removeEventListener('shopify:section:select', this._onSelect);
-      document.removeEventListener(
-        'shopify:section:deselect',
-        this._onDeselect
-      );
-      document.removeEventListener('shopify:block:select', this._onBlockSelect);
-      document.removeEventListener(
-        'shopify:block:deselect',
-        this._onBlockDeselect
-      );
-    }
-  },
+  onLoad: Function.prototype,
+  onUnload: Function.prototype,
+  onSelect: Function.prototype,
+  onDeselect: Function.prototype,
+  onBlockSelect: Function.prototype,
+  onBlockDeselect: Function.prototype,
 
   extend: function extend(extension) {
     this.extensions.push(extension); // Save original extension
 
-    var extensionClone = assign({}, extension);
+    var extensionClone = Object.assign({}, extension);
     delete extensionClone.init; // Remove init function before assigning extension properties
-    assign(this, extensionClone);
+    Object.assign(this, extensionClone);
 
     if (typeof extension.init === 'function') {
       extension.init.apply(this);
     }
-  },
-
-  _onUnload: function _onUnload(event) {
-    if (this.id !== event.detail.sectionId) {
-      return;
-    }
-
-    this.unload();
-  },
-
-  _onSelect: function _onSelect(event) {
-    this.id === event.detail.sectionId && this.onSelect(event.detail.load);
-  },
-
-  _onDeselect: function _onDeselect(event) {
-    this.id === event.detail.sectionId && this.onDeselect();
-  },
-
-  _onBlockSelect: function _onBlockSelect(event) {
-    this.id === event.detail.sectionId &&
-      this.onBlockSelect(event.detail.blockId, event.detail.load);
-  },
-
-  _onBlockDeselect: function _onBlockDeselect(event) {
-    this.id === event.detail.sectionId &&
-      this.onBlockDeselect(event.detail.blockId);
   }
 };
 
@@ -120,28 +62,35 @@ function validatePropertiesObject(value) {
 }
 
 // Object.assign() polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
-function assign(target, varArgs) {
-  // .length of function is 2
-  'use strict';
-  if (target == null) {
-    // TypeError if undefined or null
-    throw new TypeError('Cannot convert undefined or null to object');
-  }
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, 'assign', {
+    value: function assign(target, varArgs) {
+      // .length of function is 2
+      'use strict';
+      if (target == null) {
+        // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
 
-  var to = Object(target);
+      var to = Object(target);
 
-  for (var index = 1; index < arguments.length; index++) {
-    var nextSource = arguments[index];
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
 
-    if (nextSource != null) {
-      // Skip over if undefined or null
-      for (var nextKey in nextSource) {
-        // Avoid bugs when hasOwnProperty is shadowed
-        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-          to[nextKey] = nextSource[nextKey];
+        if (nextSource != null) {
+          // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
         }
       }
-    }
-  }
-  return to;
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
 }

--- a/packages/theme-sections/theme-sections.js
+++ b/packages/theme-sections/theme-sections.js
@@ -106,7 +106,7 @@ export function unload(selector) {
       })
       .indexOf(instance.id);
     instances.splice(index, 1);
-    instance.unload();
+    instance.onUnload();
   });
 }
 
@@ -152,6 +152,18 @@ export function getInstances(selector) {
   }
 
   return filteredInstances;
+}
+
+export function getInstanceById(id) {
+  var instance;
+
+  for (var i = 0; i < instances.length; i++) {
+    if (instances[i].id === id) {
+      instance = instances[i];
+      break;
+    }
+  }
+  return instance;
 }
 
 export function isInstance(selector) {
@@ -220,5 +232,49 @@ if (window.Shopify.designMode) {
     var type = container.getAttribute(SECTION_TYPE_ATTR);
 
     load(type, container);
+  });
+
+  document.addEventListener('shopify:section:unload', function(event) {
+    var id = event.detail.sectionId;
+    var container = event.target.querySelector(
+      '[' + SECTION_ID_ATTR + '="' + id + '"]'
+    );
+    var instance = getInstances(container)[0];
+
+    if (typeof instance === 'object') {
+      unload(container);
+    }
+  });
+
+  document.addEventListener('shopify:section:select', function(event) {
+    var instance = getInstanceById(event.detail.sectionId);
+
+    if (typeof instance === 'object') {
+      instance.onSelect(event.detail.load);
+    }
+  });
+
+  document.addEventListener('shopify:section:deselect', function(event) {
+    var instance = getInstanceById(event.detail.sectionId);
+
+    if (typeof instance === 'object') {
+      instance.onDeselect();
+    }
+  });
+
+  document.addEventListener('shopify:block:select', function(event) {
+    var instance = getInstanceById(event.detail.sectionId);
+
+    if (typeof instance === 'object') {
+      instance.onBlockSelect(event.detail.blockId, event.detail.load);
+    }
+  });
+
+  document.addEventListener('shopify:block:deselect', function(event) {
+    var instance = getInstanceById(event.detail.sectionId);
+
+    if (typeof instance === 'object') {
+      instance.onBlockDeselect(event.detail.blockId);
+    }
   });
 }

--- a/packages/theme-sections/theme-sections.js
+++ b/packages/theme-sections/theme-sections.js
@@ -229,9 +229,10 @@ if (window.Shopify.designMode) {
     var container = event.target.querySelector(
       '[' + SECTION_ID_ATTR + '="' + id + '"]'
     );
-    var type = container.getAttribute(SECTION_TYPE_ATTR);
 
-    load(type, container);
+    if (container !== null) {
+      load(container.getAttribute(SECTION_TYPE_ATTR), container);
+    }
   });
 
   document.addEventListener('shopify:section:unload', function(event) {

--- a/packages/theme-sections/theme-sections.test.js
+++ b/packages/theme-sections/theme-sections.test.js
@@ -10,7 +10,8 @@ import {
   load,
   unload,
   extend,
-  getInstances
+  getInstances,
+  getInstanceById
 } from './theme-sections';
 
 import Section from './section';
@@ -362,5 +363,18 @@ describe('getInstances()', () => {
       document.querySelector('#section2')
     ]);
     expect(instances.length).toBe(2);
+  });
+});
+
+describe('getInstanceById()', () => {
+  beforeEach(() => {
+    registerSections();
+    load('*');
+  });
+
+  test('retrieves section instance which matches provided id', () => {
+    var instance = getInstanceById('2');
+    expect(instance).not.toBeUndefined();
+    expect(instance.id).toBe('2');
   });
 });


### PR DESCRIPTION
Fixes https://github.com/Shopify/theme-scripts/issues/37

Replaces https://github.com/Shopify/theme-scripts/pull/38

Move Theme Editor event handling outside the scope of individual section instances, that way we don't need to add/remove them everytime we load/unload a section. 

I was also adding section instances to `instances` but they were never getting removed when the section was unloaded. This fixes that too.

cc @jonathanmoore