### PR TITLE
More control over class names and event listeners

### DIFF
--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -52,11 +52,9 @@ export function focusHash(options) {
   options = options || {};
   var hash = window.location.hash;
   var element = document.getElementById(hash.slice(1));
-  // is there a hash in the url? is it an element on the page?
 
   // if we are to ignore this element, early return
-  var ignoreSelector = options.ignore || false;
-  if (element && ignoreSelector && element.matches(ignoreSelector)) {
+  if (element && options.ignore && element.matches(options.ignore)) {
     return false;
   }
 
@@ -81,14 +79,12 @@ export function bindInPageLinks(options) {
     document.querySelectorAll('a[href^="#"]')
   );
 
-  var ignoreSelector = options.ignore || false;
-
   return links.filter(function(link) {
     if (link.hash === '#' || link.hash === '') {
       return false;
     }
 
-    if (ignoreSelector && link.matches(ignoreSelector)) {
+    if (options.ignore && link.matches(options.ignore)) {
       return false;
     }
 

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -54,7 +54,11 @@ export function focusHash(params) {
   var element = document.getElementById(hash.slice(1));
   // is there a hash in the url? is it an element on the page?
 
-  // TODO: Ignore element if it contains an ignore selector
+  // if we are to ignore this element, early return
+  var ignoreSelector = params.ignore || false;
+  if (element && ignoreSelector && element.matches(ignoreSelector)) {
+    return false;
+  }
 
   if (hash && element) {
     forceFocus(element, params);
@@ -68,7 +72,7 @@ export function focusHash(params) {
  *
  * @param {Object} params - Settings unique to your theme
  * @param {string} params.className - Class name to apply to element on focus.
- * @param {string} params.ignore - Selector for elements to not include.
+ * @param {string} params.ignore - CSS selector for elements to not include.
  */
 
 export function bindInPageLinks(params) {
@@ -76,10 +80,14 @@ export function bindInPageLinks(params) {
     document.querySelectorAll('a[href^="#"]')
   );
 
- // TODO: Ignore element if it contains an ignore selector
+  var ignoreSelector = params.ignore || false;
 
   return links.filter(function(link) {
     if (link.hash === '#' || link.hash === '') {
+      return false;
+    }
+
+    if (ignoreSelector && link.matches(ignoreSelector)) {
       return false;
     }
 
@@ -130,7 +138,7 @@ export function focusable(container) {
  * @param {Element} elementToFocus - Element to be focused on first
  * @param {Object} params - Settings unique to your theme
  * @param {string} params.className - Class name to apply to element on focus.
- * @param {string} params.ignore - Selector for elements to not include.
+ * @param {string} params.ignore - CSS selector for elements to not include.
  */
 
 var trapFocusHandlers = {};

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -17,14 +17,13 @@
 export function forceFocus(element, options) {
   options = options || {};
 
-  var className = options.className ? options.className : null;
   var savedTabIndex = element.tabIndex;
 
   element.tabIndex = -1;
   element.dataset.tabIndex = savedTabIndex;
   element.focus();
-  if (className) {
-    element.classList.add(className);
+  if (typeof options.className !== 'undefined') {
+    element.classList.add(options.className);
   }
   element.addEventListener('blur', callback);
 
@@ -33,8 +32,8 @@ export function forceFocus(element, options) {
 
     element.tabIndex = savedTabIndex;
     delete element.dataset.tabIndex;
-    if (className) {
-      element.classList.remove(className);
+    if (typeof options.className !== 'undefined') {
+      element.classList.remove(options.className);
     }
   }
 }

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -143,6 +143,7 @@ export function focusable(container) {
 var trapFocusHandlers = {};
 
 export function trapFocus(container, options) {
+  options = options || {};
   var elements = focusable(container);
   var elementToFocus = options.elementToFocus || container;
   var first = elements[0];

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -26,7 +26,7 @@ export function forceFocus(element, config) {
   if (className) {
     element.classList.add(className);
   }
-  element.addEventListener('blur', callback);
+  element.addEventListener("blur", callback);
 
   function callback(event) {
     event.target.removeEventListener(event.type, callback);
@@ -44,24 +44,24 @@ export function forceFocus(element, config) {
  * This compensates for older browsers that do not move keyboard focus to anchor links.
  * Recommendation: To be called once the page in loaded.
  *
- * @param {Object} params - Settings unique to your theme
- * @param {string} params.className - Class name to apply to element on focus.
- * @param {string} params.ignore - Selector for elements to not include.
+ * @param {Object} options - Settings unique to your theme
+ * @param {string} options.className - Class name to apply to element on focus.
+ * @param {string} options.ignore - Selector for elements to not include.
  */
 
-export function focusHash(params) {
+export function focusHash(options) {
   var hash = window.location.hash;
   var element = document.getElementById(hash.slice(1));
   // is there a hash in the url? is it an element on the page?
 
   // if we are to ignore this element, early return
-  var ignoreSelector = params.ignore || false;
+  var ignoreSelector = options.ignore || false;
   if (element && ignoreSelector && element.matches(ignoreSelector)) {
     return false;
   }
 
   if (hash && element) {
-    forceFocus(element, params);
+    forceFocus(element, options);
   }
 }
 
@@ -70,20 +70,20 @@ export function focusHash(params) {
  * This compensates for older browsers that do not move keyboard focus to anchor links.
  * Recommendation: To be called once the page in loaded.
  *
- * @param {Object} params - Settings unique to your theme
- * @param {string} params.className - Class name to apply to element on focus.
- * @param {string} params.ignore - CSS selector for elements to not include.
+ * @param {Object} options - Settings unique to your theme
+ * @param {string} options.className - Class name to apply to element on focus.
+ * @param {string} options.ignore - CSS selector for elements to not include.
  */
 
-export function bindInPageLinks(params) {
+export function bindInPageLinks(options) {
   var links = Array.prototype.slice.call(
     document.querySelectorAll('a[href^="#"]')
   );
 
-  var ignoreSelector = params.ignore || false;
+  var ignoreSelector = options.ignore || false;
 
   return links.filter(function(link) {
-    if (link.hash === '#' || link.hash === '') {
+    if (link.hash === "#" || link.hash === "") {
       return false;
     }
 
@@ -97,8 +97,8 @@ export function bindInPageLinks(params) {
       return false;
     }
 
-    link.addEventListener('click', function() {
-      forceFocus(element, params);
+    link.addEventListener("click", function() {
+      forceFocus(element, options);
     });
 
     return true;
@@ -108,15 +108,15 @@ export function bindInPageLinks(params) {
 export function focusable(container) {
   var elements = Array.from(
     container.querySelectorAll(
-      '[tabindex],' +
-        '[draggable],' +
-        'a[href],' +
-        'area,' +
-        'button:enabled,' +
-        'input:not([type=hidden]):enabled,' +
-        'object,' +
-        'select:enabled,' +
-        'textarea:enabled'
+      "[tabindex]," +
+        "[draggable]," +
+        "a[href]," +
+        "area," +
+        "button:enabled," +
+        "input:not([type=hidden]):enabled," +
+        "object," +
+        "select:enabled," +
+        "textarea:enabled"
     )
   );
 
@@ -136,17 +136,15 @@ export function focusable(container) {
  *
  * @param {Element} container - Container DOM element to trap focus inside of
  * @param {Element} elementToFocus - Element to be focused on first
- * @param {Object} params - Settings unique to your theme
- * @param {string} params.className - Class name to apply to element on focus.
- * @param {string} params.ignore - CSS selector for elements to not include.
+ * @param {Object} options - Settings unique to your theme
+ * @param {string} options.className - Class name to apply to element on focus.
  */
 
 var trapFocusHandlers = {};
 
-export function trapFocus(container, elementToFocus, params) {
-  elementToFocus = elementToFocus || container;
-
+export function trapFocus(container, options) {
   var elements = focusable(container);
+  var elementToFocus = options.elementToFocus || container;
   var first = elements[0];
   var last = elements[elements.length - 1];
 
@@ -163,11 +161,11 @@ export function trapFocus(container, elementToFocus, params) {
       event.target !== first
     )
       return;
-    document.addEventListener('keydown', trapFocusHandlers.keydown);
+    document.addEventListener("keydown", trapFocusHandlers.keydown);
   };
 
   trapFocusHandlers.focusout = function() {
-    document.removeEventListener('keydown', trapFocusHandlers.keydown);
+    document.removeEventListener("keydown", trapFocusHandlers.keydown);
   };
 
   trapFocusHandlers.keydown = function(event) {
@@ -189,17 +187,17 @@ export function trapFocus(container, elementToFocus, params) {
     }
   };
 
-  document.addEventListener('focusout', trapFocusHandlers.focusout);
-  document.addEventListener('focusin', trapFocusHandlers.focusin);
+  document.addEventListener("focusout", trapFocusHandlers.focusout);
+  document.addEventListener("focusin", trapFocusHandlers.focusin);
 
-  forceFocus(elementToFocus, params);
+  forceFocus(elementToFocus, options);
 }
 
 /**
  * Removes the trap of focus from the page
  */
 export function removeTrapFocus() {
-  document.removeEventListener('focusin', trapFocusHandlers.focusin);
-  document.removeEventListener('focusout', trapFocusHandlers.focusout);
-  document.removeEventListener('keydown', trapFocusHandlers.keydown);
+  document.removeEventListener("focusin", trapFocusHandlers.focusin);
+  document.removeEventListener("focusout", trapFocusHandlers.focusout);
+  document.removeEventListener("keydown", trapFocusHandlers.keydown);
 }

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -50,6 +50,7 @@ export function forceFocus(element, config) {
  */
 
 export function focusHash(options) {
+  options = options || {};
   var hash = window.location.hash;
   var element = document.getElementById(hash.slice(1));
   // is there a hash in the url? is it an element on the page?
@@ -76,6 +77,7 @@ export function focusHash(options) {
  */
 
 export function bindInPageLinks(options) {
+  options = options || {};
   var links = Array.prototype.slice.call(
     document.querySelectorAll('a[href^="#"]')
   );

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -145,7 +145,9 @@ var trapFocusHandlers = {};
 export function trapFocus(container, options) {
   options = options || {};
   var elements = focusable(container);
-  var elementToFocus = options.elementToFocus || container;
+  var elementToFocus = options.elementToFocus
+    ? options.elementToFocus
+    : container;
   var first = elements[0];
   var last = elements[elements.length - 1];
 

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -26,7 +26,7 @@ export function forceFocus(element, config) {
   if (className) {
     element.classList.add(className);
   }
-  element.addEventListener("blur", callback);
+  element.addEventListener('blur', callback);
 
   function callback(event) {
     event.target.removeEventListener(event.type, callback);
@@ -85,7 +85,7 @@ export function bindInPageLinks(options) {
   var ignoreSelector = options.ignore || false;
 
   return links.filter(function(link) {
-    if (link.hash === "#" || link.hash === "") {
+    if (link.hash === '#' || link.hash === '') {
       return false;
     }
 
@@ -99,7 +99,7 @@ export function bindInPageLinks(options) {
       return false;
     }
 
-    link.addEventListener("click", function() {
+    link.addEventListener('click', function() {
       forceFocus(element, options);
     });
 
@@ -110,15 +110,15 @@ export function bindInPageLinks(options) {
 export function focusable(container) {
   var elements = Array.from(
     container.querySelectorAll(
-      "[tabindex]," +
-        "[draggable]," +
-        "a[href]," +
-        "area," +
-        "button:enabled," +
-        "input:not([type=hidden]):enabled," +
-        "object," +
-        "select:enabled," +
-        "textarea:enabled"
+      '[tabindex],' +
+        '[draggable],' +
+        'a[href],' +
+        'area,' +
+        'button:enabled,' +
+        'input:not([type=hidden]):enabled,' +
+        'object,' +
+        'select:enabled,' +
+        'textarea:enabled'
     )
   );
 
@@ -166,11 +166,11 @@ export function trapFocus(container, options) {
       event.target !== first
     )
       return;
-    document.addEventListener("keydown", trapFocusHandlers.keydown);
+    document.addEventListener('keydown', trapFocusHandlers.keydown);
   };
 
   trapFocusHandlers.focusout = function() {
-    document.removeEventListener("keydown", trapFocusHandlers.keydown);
+    document.removeEventListener('keydown', trapFocusHandlers.keydown);
   };
 
   trapFocusHandlers.keydown = function(event) {
@@ -192,8 +192,8 @@ export function trapFocus(container, options) {
     }
   };
 
-  document.addEventListener("focusout", trapFocusHandlers.focusout);
-  document.addEventListener("focusin", trapFocusHandlers.focusin);
+  document.addEventListener('focusout', trapFocusHandlers.focusout);
+  document.addEventListener('focusin', trapFocusHandlers.focusin);
 
   forceFocus(elementToFocus, options);
 }
@@ -202,7 +202,7 @@ export function trapFocus(container, options) {
  * Removes the trap of focus from the page
  */
 export function removeTrapFocus() {
-  document.removeEventListener("focusin", trapFocusHandlers.focusin);
-  document.removeEventListener("focusout", trapFocusHandlers.focusout);
-  document.removeEventListener("keydown", trapFocusHandlers.keydown);
+  document.removeEventListener('focusin', trapFocusHandlers.focusin);
+  document.removeEventListener('focusout', trapFocusHandlers.focusout);
+  document.removeEventListener('keydown', trapFocusHandlers.keydown);
 }

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -147,9 +147,7 @@ var trapFocusHandlers = {};
 export function trapFocus(container, options) {
   options = options || {};
   var elements = focusable(container);
-  var elementToFocus = options.elementToFocus
-    ? options.elementToFocus
-    : container;
+  var elementToFocus = options.elementToFocus || container;
   var first = elements[0];
   var last = elements[elements.length - 1];
 

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -11,13 +11,13 @@
  * eg move focus to a modal that is opened. Used in trapFocus()
  *
  * @param {Element} container - Container DOM element to trap focus inside of
- * @param {Object} config - Settings unique to your theme
- * @param {string} config.className - Class name to apply to element on focus.
+ * @param {Object} options - Settings unique to your theme
+ * @param {string} options.className - Class name to apply to element on focus.
  */
-export function forceFocus(element, config) {
-  config = config || {};
+export function forceFocus(element, options) {
+  options = options || {};
 
-  var className = config.className ? config.className : null;
+  var className = options.className ? options.className : null;
   var savedTabIndex = element.tabIndex;
 
   element.tabIndex = -1;

--- a/packages/theme-a11y/theme-a11y.puppeteer.test.js
+++ b/packages/theme-a11y/theme-a11y.puppeteer.test.js
@@ -1,11 +1,11 @@
 import {
-  pageLinkFocus,
+  forceFocus,
   focusable,
   trapFocus,
   removeTrapFocus
-} from './theme-a11y';
+} from "./theme-a11y";
 
-describe('trapFocus()', () => {
+describe("trapFocus()", () => {
   beforeEach(async () => {
     // This is a super smelly way of exposing the functions needed to perform the
     // tests I want. Would love a better way!
@@ -13,7 +13,7 @@ describe('trapFocus()', () => {
     <script type="module">
       window.trapFocusHandlers = {};
       window.removeTrapFocus = ${removeTrapFocus.toString()};
-      window.pageLinkFocus = ${pageLinkFocus.toString()};
+      window.forceFocus = ${forceFocus.toString()};
       window.focusable = ${focusable.toString()};
       window.trapFocus = ${trapFocus.toString()};
     </script>
@@ -29,62 +29,62 @@ describe('trapFocus()', () => {
     </div>`);
   });
 
-  test('sets the intial focus on the container by default', async () => {
+  test("sets the intial focus on the container by default", async () => {
     await page.evaluate(() => {
-      const container = document.getElementById('container');
+      const container = document.getElementById("container");
       window.trapFocus(container);
     });
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe('container');
+    await expect(activeElement).toBe("container");
   });
 
-  test('accepts an optional second parameter to specify what element to initially focus on', async () => {
+  test("accepts an optional second parameter to specify what element to initially focus on", async () => {
     await page.evaluate(() => {
-      const container = document.getElementById('container');
-      const input2 = document.getElementById('textInput2');
+      const container = document.getElementById("container");
+      const input2 = document.getElementById("textInput2");
       window.trapFocus(container, input2);
     });
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe('textInput2');
+    await expect(activeElement).toBe("textInput2");
   });
 
-  test('focuses the first tabable element after tabbing the last tabable element in a container', async () => {
+  test("focuses the first tabable element after tabbing the last tabable element in a container", async () => {
     await page.evaluate(() => {
-      const container = document.getElementById('container');
-      const lastElement = document.getElementById('button');
+      const container = document.getElementById("container");
+      const lastElement = document.getElementById("button");
       window.trapFocus(container);
     });
 
-    await page.keyboard.press('Tab');
+    await page.keyboard.press("Tab");
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe('textInput1');
+    await expect(activeElement).toBe("textInput1");
   });
 
-  test('focuses on the last tabable and visible element when shift-tabbing from first tabbable element', async () => {
+  test("focuses on the last tabable and visible element when shift-tabbing from first tabbable element", async () => {
     await page.evaluate(() => {
-      const container = document.getElementById('container');
+      const container = document.getElementById("container");
       window.trapFocus(container);
     });
 
-    await page.keyboard.down('Shift');
-    await page.keyboard.press('Tab');
-    await page.keyboard.up('Shift');
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Tab");
+    await page.keyboard.up("Shift");
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe('button');
+    await expect(activeElement).toBe("button");
   });
 
-  test('focuses first tabable and visible element if focus leaves the container', async () => {
+  test("focuses first tabable and visible element if focus leaves the container", async () => {
     const activeElement = await page.evaluate(() => {
-      const container = document.getElementById('container');
-      const outsideLink = document.getElementById('outsideLink');
+      const container = document.getElementById("container");
+      const outsideLink = document.getElementById("outsideLink");
 
       window.trapFocus(container);
       outsideLink.focus();
@@ -92,27 +92,27 @@ describe('trapFocus()', () => {
       return document.activeElement.id;
     });
 
-    await expect(activeElement).toBe('textInput1');
+    await expect(activeElement).toBe("textInput1");
   });
 
-  test('removes the previous trapFocus() before applying applying a new instance of trapFocus()', async () => {
+  test("removes the previous trapFocus() before applying applying a new instance of trapFocus()", async () => {
     await page.evaluate(() => {
-      window.trapFocus(document.getElementById('container'));
-      window.trapFocus(document.getElementById('container2'));
+      window.trapFocus(document.getElementById("container"));
+      window.trapFocus(document.getElementById("container2"));
     });
 
-    await page.keyboard.down('Shift');
-    await page.keyboard.press('Tab');
-    await page.keyboard.press('Tab');
-    await page.keyboard.up('Shift');
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.up("Shift");
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe('textInput3');
+    await expect(activeElement).toBe("textInput3");
   });
 });
 
-describe('focusable()', () => {
+describe("focusable()", () => {
   async function expectElements(valid, invalid) {
     const matchIds = await page.evaluate(() => {
       var ids = [];
@@ -122,16 +122,16 @@ describe('focusable()', () => {
 
     expect(matchIds).toEqual(expect.arrayContaining(valid));
 
-    if (typeof invalid !== 'undefined') {
+    if (typeof invalid !== "undefined") {
       expect(matchIds).not.toEqual(expect.arrayContaining(invalid));
     }
   }
 
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof focusable).toBe('function');
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof focusable).toBe("function");
   });
 
-  test('selects valid <a> elements', async () => {
+  test("selects valid <a> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -140,13 +140,13 @@ describe('focusable()', () => {
       <a id="withoutHref"></a>
     `);
 
-    const valid = ['withHref'];
-    const invalid = ['withoutHref'];
+    const valid = ["withHref"];
+    const invalid = ["withoutHref"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects valid <area> elements', async () => {
+  test("selects valid <area> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -156,12 +156,12 @@ describe('focusable()', () => {
       </map>
     `);
 
-    const valid = ['area'];
+    const valid = ["area"];
 
     await expectElements(valid);
   });
 
-  test('selects enabled <button> elements', async () => {
+  test("selects enabled <button> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -170,13 +170,13 @@ describe('focusable()', () => {
       <button id="disabledButton" disabled></button>
     `);
 
-    const valid = ['button'];
-    const invalid = ['disabledButton'];
+    const valid = ["button"];
+    const invalid = ["disabledButton"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects enabled, non-hidden input elements', async () => {
+  test("selects enabled, non-hidden input elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -185,13 +185,13 @@ describe('focusable()', () => {
       <input type="hidden" id="hiddenInput"></input>
     `);
 
-    const valid = ['input'];
-    const invalid = ['hiddenInput'];
+    const valid = ["input"];
+    const invalid = ["hiddenInput"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects valid <object> elements', async () => {
+  test("selects valid <object> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -199,12 +199,12 @@ describe('focusable()', () => {
       <object id="object" data="movie.swf" type="application/x-shockwave-flash" />
     `);
 
-    const valid = ['object'];
+    const valid = ["object"];
 
     await expectElements(valid);
   });
 
-  test('selects enabled <select> elements', async () => {
+  test("selects enabled <select> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -217,13 +217,13 @@ describe('focusable()', () => {
       </select>
     `);
 
-    const valid = ['validSelect'];
-    const invalid = ['disabledSelect'];
+    const valid = ["validSelect"];
+    const invalid = ["disabledSelect"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects enabled <textarea> elements', async () => {
+  test("selects enabled <textarea> elements", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -232,13 +232,13 @@ describe('focusable()', () => {
       <textarea id="disabledTextArea" disabled></textarea>
     `);
 
-    const valid = ['validTextArea'];
-    const invalid = ['disabledTextArea'];
+    const valid = ["validTextArea"];
+    const invalid = ["disabledTextArea"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects elements with tabindex attribute', async () => {
+  test("selects elements with tabindex attribute", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -247,13 +247,13 @@ describe('focusable()', () => {
       <div id="withoutTabIndex"></div>
     `);
 
-    const valid = ['withTabIndex'];
-    const invalid = ['withoutTabIndex'];
+    const valid = ["withTabIndex"];
+    const invalid = ["withoutTabIndex"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects elements with draggable attribute', async () => {
+  test("selects elements with draggable attribute", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -263,13 +263,13 @@ describe('focusable()', () => {
       <div id="withoutDraggable"></div>
     `);
 
-    const valid = ['draggableTrue'];
-    const invalid = ['draggableFalse', 'withoutDraggable'];
+    const valid = ["draggableTrue"];
+    const invalid = ["draggableFalse", "withoutDraggable"];
 
     await expectElements(valid, invalid);
   });
 
-  test('selects only elements which are visible', async () => {
+  test("selects only elements which are visible", async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -282,21 +282,21 @@ describe('focusable()', () => {
       </div>
     `);
 
-    const valid = ['visibleButton', 'transparentButton'];
-    const invalid = ['hiddenButton', 'hiddenChildButton'];
+    const valid = ["visibleButton", "transparentButton"];
+    const invalid = ["hiddenButton", "hiddenChildButton"];
 
     await expectElements(valid, invalid);
   });
 });
 
-describe('trapFocus()', () => {
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof trapFocus).toBe('function');
+describe("trapFocus()", () => {
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof trapFocus).toBe("function");
   });
 });
 
-describe('removeTrapFocus()', () => {
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof removeTrapFocus).toBe('function');
+describe("removeTrapFocus()", () => {
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof removeTrapFocus).toBe("function");
   });
 });

--- a/packages/theme-a11y/theme-a11y.puppeteer.test.js
+++ b/packages/theme-a11y/theme-a11y.puppeteer.test.js
@@ -44,7 +44,9 @@ describe("trapFocus()", () => {
     await page.evaluate(() => {
       const container = document.getElementById("container");
       const input2 = document.getElementById("textInput2");
-      window.trapFocus(container, input2);
+      window.trapFocus(container, {
+        elementToFocus: input2
+      });
     });
 
     const activeElement = await page.evaluate(() => document.activeElement.id);

--- a/packages/theme-a11y/theme-a11y.puppeteer.test.js
+++ b/packages/theme-a11y/theme-a11y.puppeteer.test.js
@@ -3,9 +3,9 @@ import {
   focusable,
   trapFocus,
   removeTrapFocus
-} from "./theme-a11y";
+} from './theme-a11y';
 
-describe("trapFocus()", () => {
+describe('trapFocus()', () => {
   beforeEach(async () => {
     // This is a super smelly way of exposing the functions needed to perform the
     // tests I want. Would love a better way!
@@ -29,21 +29,21 @@ describe("trapFocus()", () => {
     </div>`);
   });
 
-  test("sets the intial focus on the container by default", async () => {
+  test('sets the intial focus on the container by default', async () => {
     await page.evaluate(() => {
-      const container = document.getElementById("container");
+      const container = document.getElementById('container');
       window.trapFocus(container);
     });
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe("container");
+    await expect(activeElement).toBe('container');
   });
 
-  test("accepts an optional second parameter to specify what element to initially focus on", async () => {
+  test('accepts an optional second parameter to specify what element to initially focus on', async () => {
     await page.evaluate(() => {
-      const container = document.getElementById("container");
-      const input2 = document.getElementById("textInput2");
+      const container = document.getElementById('container');
+      const input2 = document.getElementById('textInput2');
       window.trapFocus(container, {
         elementToFocus: input2
       });
@@ -51,42 +51,42 @@ describe("trapFocus()", () => {
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe("textInput2");
+    await expect(activeElement).toBe('textInput2');
   });
 
-  test("focuses the first tabable element after tabbing the last tabable element in a container", async () => {
+  test('focuses the first tabable element after tabbing the last tabable element in a container', async () => {
     await page.evaluate(() => {
-      const container = document.getElementById("container");
-      const lastElement = document.getElementById("button");
+      const container = document.getElementById('container');
+      const lastElement = document.getElementById('button');
       window.trapFocus(container);
     });
 
-    await page.keyboard.press("Tab");
+    await page.keyboard.press('Tab');
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe("textInput1");
+    await expect(activeElement).toBe('textInput1');
   });
 
-  test("focuses on the last tabable and visible element when shift-tabbing from first tabbable element", async () => {
+  test('focuses on the last tabable and visible element when shift-tabbing from first tabbable element', async () => {
     await page.evaluate(() => {
-      const container = document.getElementById("container");
+      const container = document.getElementById('container');
       window.trapFocus(container);
     });
 
-    await page.keyboard.down("Shift");
-    await page.keyboard.press("Tab");
-    await page.keyboard.up("Shift");
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Tab');
+    await page.keyboard.up('Shift');
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe("button");
+    await expect(activeElement).toBe('button');
   });
 
-  test("focuses first tabable and visible element if focus leaves the container", async () => {
+  test('focuses first tabable and visible element if focus leaves the container', async () => {
     const activeElement = await page.evaluate(() => {
-      const container = document.getElementById("container");
-      const outsideLink = document.getElementById("outsideLink");
+      const container = document.getElementById('container');
+      const outsideLink = document.getElementById('outsideLink');
 
       window.trapFocus(container);
       outsideLink.focus();
@@ -94,27 +94,27 @@ describe("trapFocus()", () => {
       return document.activeElement.id;
     });
 
-    await expect(activeElement).toBe("textInput1");
+    await expect(activeElement).toBe('textInput1');
   });
 
-  test("removes the previous trapFocus() before applying applying a new instance of trapFocus()", async () => {
+  test('removes the previous trapFocus() before applying applying a new instance of trapFocus()', async () => {
     await page.evaluate(() => {
-      window.trapFocus(document.getElementById("container"));
-      window.trapFocus(document.getElementById("container2"));
+      window.trapFocus(document.getElementById('container'));
+      window.trapFocus(document.getElementById('container2'));
     });
 
-    await page.keyboard.down("Shift");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.up("Shift");
+    await page.keyboard.down('Shift');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.up('Shift');
 
     const activeElement = await page.evaluate(() => document.activeElement.id);
 
-    await expect(activeElement).toBe("textInput3");
+    await expect(activeElement).toBe('textInput3');
   });
 });
 
-describe("focusable()", () => {
+describe('focusable()', () => {
   async function expectElements(valid, invalid) {
     const matchIds = await page.evaluate(() => {
       var ids = [];
@@ -124,16 +124,16 @@ describe("focusable()", () => {
 
     expect(matchIds).toEqual(expect.arrayContaining(valid));
 
-    if (typeof invalid !== "undefined") {
+    if (typeof invalid !== 'undefined') {
       expect(matchIds).not.toEqual(expect.arrayContaining(invalid));
     }
   }
 
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof focusable).toBe("function");
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof focusable).toBe('function');
   });
 
-  test("selects valid <a> elements", async () => {
+  test('selects valid <a> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -142,13 +142,13 @@ describe("focusable()", () => {
       <a id="withoutHref"></a>
     `);
 
-    const valid = ["withHref"];
-    const invalid = ["withoutHref"];
+    const valid = ['withHref'];
+    const invalid = ['withoutHref'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects valid <area> elements", async () => {
+  test('selects valid <area> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -158,12 +158,12 @@ describe("focusable()", () => {
       </map>
     `);
 
-    const valid = ["area"];
+    const valid = ['area'];
 
     await expectElements(valid);
   });
 
-  test("selects enabled <button> elements", async () => {
+  test('selects enabled <button> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -172,13 +172,13 @@ describe("focusable()", () => {
       <button id="disabledButton" disabled></button>
     `);
 
-    const valid = ["button"];
-    const invalid = ["disabledButton"];
+    const valid = ['button'];
+    const invalid = ['disabledButton'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects enabled, non-hidden input elements", async () => {
+  test('selects enabled, non-hidden input elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -187,13 +187,13 @@ describe("focusable()", () => {
       <input type="hidden" id="hiddenInput"></input>
     `);
 
-    const valid = ["input"];
-    const invalid = ["hiddenInput"];
+    const valid = ['input'];
+    const invalid = ['hiddenInput'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects valid <object> elements", async () => {
+  test('selects valid <object> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -201,12 +201,12 @@ describe("focusable()", () => {
       <object id="object" data="movie.swf" type="application/x-shockwave-flash" />
     `);
 
-    const valid = ["object"];
+    const valid = ['object'];
 
     await expectElements(valid);
   });
 
-  test("selects enabled <select> elements", async () => {
+  test('selects enabled <select> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -219,13 +219,13 @@ describe("focusable()", () => {
       </select>
     `);
 
-    const valid = ["validSelect"];
-    const invalid = ["disabledSelect"];
+    const valid = ['validSelect'];
+    const invalid = ['disabledSelect'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects enabled <textarea> elements", async () => {
+  test('selects enabled <textarea> elements', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -234,13 +234,13 @@ describe("focusable()", () => {
       <textarea id="disabledTextArea" disabled></textarea>
     `);
 
-    const valid = ["validTextArea"];
-    const invalid = ["disabledTextArea"];
+    const valid = ['validTextArea'];
+    const invalid = ['disabledTextArea'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects elements with tabindex attribute", async () => {
+  test('selects elements with tabindex attribute', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -249,13 +249,13 @@ describe("focusable()", () => {
       <div id="withoutTabIndex"></div>
     `);
 
-    const valid = ["withTabIndex"];
-    const invalid = ["withoutTabIndex"];
+    const valid = ['withTabIndex'];
+    const invalid = ['withoutTabIndex'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects elements with draggable attribute", async () => {
+  test('selects elements with draggable attribute', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -265,13 +265,13 @@ describe("focusable()", () => {
       <div id="withoutDraggable"></div>
     `);
 
-    const valid = ["draggableTrue"];
-    const invalid = ["draggableFalse", "withoutDraggable"];
+    const valid = ['draggableTrue'];
+    const invalid = ['draggableFalse', 'withoutDraggable'];
 
     await expectElements(valid, invalid);
   });
 
-  test("selects only elements which are visible", async () => {
+  test('selects only elements which are visible', async () => {
     await page.setContent(`
       <script type="module">
         window.focusable = ${focusable.toString()};
@@ -284,21 +284,21 @@ describe("focusable()", () => {
       </div>
     `);
 
-    const valid = ["visibleButton", "transparentButton"];
-    const invalid = ["hiddenButton", "hiddenChildButton"];
+    const valid = ['visibleButton', 'transparentButton'];
+    const invalid = ['hiddenButton', 'hiddenChildButton'];
 
     await expectElements(valid, invalid);
   });
 });
 
-describe("trapFocus()", () => {
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof trapFocus).toBe("function");
+describe('trapFocus()', () => {
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof trapFocus).toBe('function');
   });
 });
 
-describe("removeTrapFocus()", () => {
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof removeTrapFocus).toBe("function");
+describe('removeTrapFocus()', () => {
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof removeTrapFocus).toBe('function');
   });
 });

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import path from "path";
+import path from 'path';
 import {
   forceFocus,
   focusHash,
@@ -10,22 +10,22 @@ import {
   focusable,
   trapFocus,
   removeTrapFocus
-} from "./theme-a11y";
+} from './theme-a11y';
 
-describe("forceFocus()", () => {
+describe('forceFocus()', () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<div id="nonFocusableElement"></div>' +
       '<button id="focusableElement" tabIndex=3 class="myClass">';
   });
 
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof forceFocus).toBe("function");
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof forceFocus).toBe('function');
   });
 
   test("adds a 'tabindex=-1' attribute", () => {
-    const nonFocusableElement = document.getElementById("nonFocusableElement");
-    const focusableElement = document.getElementById("focusableElement");
+    const nonFocusableElement = document.getElementById('nonFocusableElement');
+    const focusableElement = document.getElementById('focusableElement');
 
     forceFocus(nonFocusableElement);
     expect(nonFocusableElement.tabIndex).toBe(-1);
@@ -34,8 +34,8 @@ describe("forceFocus()", () => {
     expect(focusableElement.tabIndex).toBe(-1);
   });
 
-  test("reserves the original tabindex value in a data-tabIndex attribute", () => {
-    const focusableElement = document.getElementById("focusableElement");
+  test('reserves the original tabindex value in a data-tabIndex attribute', () => {
+    const focusableElement = document.getElementById('focusableElement');
 
     focusableElement.tabIndex = 3;
     forceFocus(focusableElement);
@@ -43,25 +43,25 @@ describe("forceFocus()", () => {
     expect(parseInt(focusableElement.dataset.tabIndex)).toBe(3);
   });
 
-  test("adds a focus state", () => {
-    const focusableElement = document.getElementById("focusableElement");
+  test('adds a focus state', () => {
+    const focusableElement = document.getElementById('focusableElement');
 
     forceFocus(focusableElement);
 
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test("adds an overrided class name", () => {
-    const focusableElement = document.getElementById("focusableElement");
-    const customClass = "custom-class";
+  test('adds an overrided class name', () => {
+    const focusableElement = document.getElementById('focusableElement');
+    const customClass = 'custom-class';
     forceFocus(focusableElement, { className: customClass });
 
     expect(focusableElement.classList.contains(customClass)).toBeTruthy();
   });
 
-  test("resets the element to its original state on blur", () => {
-    const focusableElement = document.getElementById("focusableElement");
-    const nonFocusableElement = document.getElementById("nonFocusableElement");
+  test('resets the element to its original state on blur', () => {
+    const focusableElement = document.getElementById('focusableElement');
+    const nonFocusableElement = document.getElementById('nonFocusableElement');
     const clone = focusableElement.cloneNode(true);
 
     forceFocus(focusableElement);
@@ -71,30 +71,30 @@ describe("forceFocus()", () => {
   });
 });
 
-describe("focusHash()", () => {
+describe('focusHash()', () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<div id="nonFocusableElement"></div>' +
       '<button id="focusableElement" tabIndex=3 class="myClass">';
   });
 
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof focusHash).toBe("function");
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof focusHash).toBe('function');
   });
 
-  test("focuses an element whose ID is specified in the URL hash", () => {
-    const focusableElement = document.getElementById("focusableElement");
+  test('focuses an element whose ID is specified in the URL hash', () => {
+    const focusableElement = document.getElementById('focusableElement');
 
-    window.location.hash = "focusableElement";
+    window.location.hash = 'focusableElement';
     focusHash();
 
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test("does not change the focus if element specified does not exist", () => {
-    const focusableElement = document.getElementById("focusableElement");
+  test('does not change the focus if element specified does not exist', () => {
+    const focusableElement = document.getElementById('focusableElement');
 
-    window.location.hash = "otherElement";
+    window.location.hash = 'otherElement';
     forceFocus(focusableElement);
     focusHash();
 
@@ -102,7 +102,7 @@ describe("focusHash()", () => {
   });
 });
 
-describe("bindInPageLinks()", () => {
+describe('bindInPageLinks()', () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<a id="link" href="#title"></a>' +
@@ -111,11 +111,11 @@ describe("bindInPageLinks()", () => {
       '<h1 id="title">Title</h1>';
   });
 
-  test("is a function exported by theme-a11y.js", () => {
-    expect(typeof bindInPageLinks).toBe("function");
+  test('is a function exported by theme-a11y.js', () => {
+    expect(typeof bindInPageLinks).toBe('function');
   });
 
-  test("returns array of link elements that were binded", () => {
+  test('returns array of link elements that were binded', () => {
     const links = bindInPageLinks();
 
     expect(Array.isArray(links)).toBeTruthy;
@@ -123,8 +123,8 @@ describe("bindInPageLinks()", () => {
   });
 
   test("adds an event handler that focuses the element referred to in an <a> element w/ a href='#...' when it is clicked", () => {
-    const link = document.getElementById("link");
-    const title = document.getElementById("title");
+    const link = document.getElementById('link');
+    const title = document.getElementById('title');
 
     bindInPageLinks();
 

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -51,7 +51,7 @@ describe('forceFocus()', () => {
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test('adds an overrided class name', () => {
+  test('adds a class name if specified in the options', () => {
     const focusableElement = document.getElementById('focusableElement');
     const customClass = 'custom-class';
     forceFocus(focusableElement, { className: customClass });

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -101,7 +101,7 @@ describe('focusHash()', () => {
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test('does not change the focus if element specified in the URL hash is ignored', () => {
+  test('does not focus if element specified in the URL hash is ignored', () => {
     const body = document.getElementsByTagName('body');
 
     window.location.hash = 'focusableElement';

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -119,15 +119,19 @@ describe('bindInPageLinks()', () => {
       '<a id="link" href="#title"></a>' +
       '<a id="invalidLink1" href="#"></a>' +
       '<a id="invalidLink2" href="/otherlink"></a>' +
-      '<h1 id="title">Title</h1>';
+      '<a id="ignoredLink" class="js-ignore-link" href="#title2"></a>' +
+      '<h1 id="title">Title</h1>' +
+      '<h2 id="title2">Title 2</h2>';
   });
 
   test('is a function exported by theme-a11y.js', () => {
     expect(typeof bindInPageLinks).toBe('function');
   });
 
-  test('returns array of link elements that were binded', () => {
-    const links = bindInPageLinks();
+  test('returns array of link elements that were binded and not ignored', () => {
+    const links = bindInPageLinks({
+      ignore: '.js-ignore-link'
+    });
 
     expect(Array.isArray(links)).toBeTruthy;
     expect(links.length).toBe(1);

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -51,14 +51,6 @@ describe("forceFocus()", () => {
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test("adds the default class name 'js-focus-hidden'", () => {
-    const focusableElement = document.getElementById("focusableElement");
-    const defaultClass = "js-focus-hidden";
-    forceFocus(focusableElement);
-
-    expect(focusableElement.classList.contains(defaultClass)).toBeTruthy();
-  });
-
   test("adds an overrided class name", () => {
     const focusableElement = document.getElementById("focusableElement");
     const customClass = "custom-class";

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -2,115 +2,115 @@
  * @jest-environment jsdom
  */
 
-import path from 'path';
+import path from "path";
 import {
-  pageLinkFocus,
+  forceFocus,
   focusHash,
   bindInPageLinks,
   focusable,
   trapFocus,
   removeTrapFocus
-} from './theme-a11y';
+} from "./theme-a11y";
 
-describe('pageLinkFocus()', () => {
+describe("forceFocus()", () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<div id="nonFocusableElement"></div>' +
       '<button id="focusableElement" tabIndex=3 class="myClass">';
   });
 
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof pageLinkFocus).toBe('function');
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof forceFocus).toBe("function");
   });
 
   test("adds a 'tabindex=-1' attribute", () => {
-    const nonFocusableElement = document.getElementById('nonFocusableElement');
-    const focusableElement = document.getElementById('focusableElement');
+    const nonFocusableElement = document.getElementById("nonFocusableElement");
+    const focusableElement = document.getElementById("focusableElement");
 
-    pageLinkFocus(nonFocusableElement);
+    forceFocus(nonFocusableElement);
     expect(nonFocusableElement.tabIndex).toBe(-1);
 
-    pageLinkFocus(focusableElement);
+    forceFocus(focusableElement);
     expect(focusableElement.tabIndex).toBe(-1);
   });
 
-  test('reserves the original tabindex value in a data-tabIndex attribute', () => {
-    const focusableElement = document.getElementById('focusableElement');
+  test("reserves the original tabindex value in a data-tabIndex attribute", () => {
+    const focusableElement = document.getElementById("focusableElement");
 
     focusableElement.tabIndex = 3;
-    pageLinkFocus(focusableElement);
+    forceFocus(focusableElement);
 
     expect(parseInt(focusableElement.dataset.tabIndex)).toBe(3);
   });
 
-  test('adds a focus state', () => {
-    const focusableElement = document.getElementById('focusableElement');
+  test("adds a focus state", () => {
+    const focusableElement = document.getElementById("focusableElement");
 
-    pageLinkFocus(focusableElement);
+    forceFocus(focusableElement);
 
     expect(document.activeElement).toBe(focusableElement);
   });
 
   test("adds the default class name 'js-focus-hidden'", () => {
-    const focusableElement = document.getElementById('focusableElement');
-    const defaultClass = 'js-focus-hidden';
-    pageLinkFocus(focusableElement);
+    const focusableElement = document.getElementById("focusableElement");
+    const defaultClass = "js-focus-hidden";
+    forceFocus(focusableElement);
 
     expect(focusableElement.classList.contains(defaultClass)).toBeTruthy();
   });
 
-  test('adds an overrided class name', () => {
-    const focusableElement = document.getElementById('focusableElement');
-    const customClass = 'custom-class';
-    pageLinkFocus(focusableElement, { className: customClass });
+  test("adds an overrided class name", () => {
+    const focusableElement = document.getElementById("focusableElement");
+    const customClass = "custom-class";
+    forceFocus(focusableElement, { className: customClass });
 
     expect(focusableElement.classList.contains(customClass)).toBeTruthy();
   });
 
-  test('resets the element to its original state on blur', () => {
-    const focusableElement = document.getElementById('focusableElement');
-    const nonFocusableElement = document.getElementById('nonFocusableElement');
+  test("resets the element to its original state on blur", () => {
+    const focusableElement = document.getElementById("focusableElement");
+    const nonFocusableElement = document.getElementById("nonFocusableElement");
     const clone = focusableElement.cloneNode(true);
 
-    pageLinkFocus(focusableElement);
-    pageLinkFocus(nonFocusableElement);
+    forceFocus(focusableElement);
+    forceFocus(nonFocusableElement);
 
     expect(focusableElement).toEqual(clone);
   });
 });
 
-describe('focusHash()', () => {
+describe("focusHash()", () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<div id="nonFocusableElement"></div>' +
       '<button id="focusableElement" tabIndex=3 class="myClass">';
   });
 
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof focusHash).toBe('function');
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof focusHash).toBe("function");
   });
 
-  test('focuses an element whose ID is specified in the URL hash', () => {
-    const focusableElement = document.getElementById('focusableElement');
+  test("focuses an element whose ID is specified in the URL hash", () => {
+    const focusableElement = document.getElementById("focusableElement");
 
-    window.location.hash = 'focusableElement';
+    window.location.hash = "focusableElement";
     focusHash();
 
     expect(document.activeElement).toBe(focusableElement);
   });
 
-  test('does not change the focus if element specified does not exist', () => {
-    const focusableElement = document.getElementById('focusableElement');
+  test("does not change the focus if element specified does not exist", () => {
+    const focusableElement = document.getElementById("focusableElement");
 
-    window.location.hash = 'otherElement';
-    pageLinkFocus(focusableElement);
+    window.location.hash = "otherElement";
+    forceFocus(focusableElement);
     focusHash();
 
     expect(document.activeElement).toBe(focusableElement);
   });
 });
 
-describe('bindInPageLinks()', () => {
+describe("bindInPageLinks()", () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<a id="link" href="#title"></a>' +
@@ -119,11 +119,11 @@ describe('bindInPageLinks()', () => {
       '<h1 id="title">Title</h1>';
   });
 
-  test('is a function exported by theme-a11y.js', () => {
-    expect(typeof bindInPageLinks).toBe('function');
+  test("is a function exported by theme-a11y.js", () => {
+    expect(typeof bindInPageLinks).toBe("function");
   });
 
-  test('returns array of link elements that were binded', () => {
+  test("returns array of link elements that were binded", () => {
     const links = bindInPageLinks();
 
     expect(Array.isArray(links)).toBeTruthy;
@@ -131,8 +131,8 @@ describe('bindInPageLinks()', () => {
   });
 
   test("adds an event handler that focuses the element referred to in an <a> element w/ a href='#...' when it is clicked", () => {
-    const link = document.getElementById('link');
-    const title = document.getElementById('title');
+    const link = document.getElementById("link");
+    const title = document.getElementById("title");
 
     bindInPageLinks();
 

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -135,6 +135,11 @@ describe('bindInPageLinks()', () => {
 
     expect(Array.isArray(links)).toBeTruthy;
     expect(links.length).toBe(1);
+    expect(links).toEqual(
+      expect.not.arrayContaining(
+        Array.from(document.querySelectorAll('.js-ignore-link'))
+      )
+    );
   });
 
   test("adds an event handler that focuses the element referred to in an <a> element w/ a href='#...' when it is clicked", () => {

--- a/packages/theme-a11y/theme-a11y.test.js
+++ b/packages/theme-a11y/theme-a11y.test.js
@@ -100,6 +100,17 @@ describe('focusHash()', () => {
 
     expect(document.activeElement).toBe(focusableElement);
   });
+
+  test('does not change the focus if element specified in the URL hash is ignored', () => {
+    const body = document.getElementsByTagName('body');
+
+    window.location.hash = 'focusableElement';
+    focusHash({
+      ignore: '#focusableElement'
+    });
+
+    expect(document.activeElement).toBe(body[0]);
+  });
 });
 
 describe('bindInPageLinks()', () => {


### PR DESCRIPTION
This PR addresses some issues I noticed while converting an existing project to use `@shopify/theme-scripts`:

### Control over class name

This `pageLinkFocus ` method was adding the `js-focus-hidden` to my elements all the time.  There's two reasons for this.
1. If you don't provide a class, it will assign `js-focus-hidden`.
2. If you're using a method that calls `pageLinkFocus()`, like `focusHash`, there is no way to provide a `config` argument, so you are always getting the `js-focus-hidden` class added.

My solution address this in a couple steps:
1. `className` is now a ternary function. If you don't have a `config.className`, then its value is `null`
2. Methods that call `forceFocus` now accept a `params` object so that they can pass a class to the newly named `forceFocus` method. (More on that below)

### Naming of `pageLinkFocus()`

I renamed `pageLinkFocus` to `forceFocus` so that it's more descriptive to what it will do.  In addition, I gave some example usages in the comments and removed a jQuery reference.

Reason for the rename: The `trapFocus` method was calling `pageLinkFocus`. However, the element you may focus on might be a link, but it also might be a `<button>` element like when you open menu drawer and the focus stays on the `<button>`.  Or, it might be an `<h1>` or simple `<div>` like when you open a cart modal on screen and context is moved.

I realize this makes the PR a breaking change, so I'm open to talk about it. :) 

Note: By stopping the behaviour of always applying the `js-focus-hidden` class might also be considered a breaking change. Theoretically, there could be projects that rely on it being applied.

### Control over event listeners

I really wasn't sure what the point of `bindInPageLinks` and `hashFocus` were for awhile since I thought that browsers did this naturally ™️ .  ... Well, after asking around it turns out that is only a very recent change in browsers and those methods are good for older browsers.  

Solution: I put a little note.

Now that' I'm a fan of `bindInPageLinks`, I noticed that it is much more aggressive than what I was previously using in my project. Before, I would tell the `a11y` script what "in page links" to look for.  Now that `bindPageLinks` grabs all of them, I figure it would be a good idea to give devs a way to tell the script to ignore certain links/elements.

Solution: I added an `ignore` property to the `params` object so that devs can specify a CSS selector to have `hashFocus` and `bindInPageLinks` to ignore an element.

## Ideas for exploration

I would like to propose changing how arguments are passed into functions some more.  Namely, I'd prefer if there was only one object argument.

```js
a11y.trapFocus(container, elementToFocus, {
  className: 'string'
});
```

Instead of having to remember whether `container` comes first of `elementToFocus`, I personally relying on named properties.

```js
a11y.trapFocus({
  container: HTML_element,
  elementToFocus: HTML_element,
  className: 'string'
});
```

This is personal preference however. If someone thinks this is a bad idea, I'm happy to hear why 😄 

I know that this now relies on devs to know the name of properties instead of the "just" order.

## TODO:

* [x] Rewrite tests.
* [ ] Make a major release as this PR introduces breaking changes.