### PR TITLE
Add alpha/beta packages to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 packages/**/rollup.config.js
 jest.config.js
+wallaby.js
+packages/theme-currency
+packages/theme-images
+packages/theme-rte
+packages/theme-variants

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "yarn && lerna bootstrap",
     "build": "lerna run build",
     "publish": "lerna publish",
-    "lint": "yarn eslint packages/theme-a11y packages/theme-cart packages/theme-product packages/theme-sections"
+    "lint": "yarn eslint ./"
   },
   "repository": "https://github.com/Shopify/theme-scripts",
   "keywords": [


### PR DESCRIPTION
These packages have not been been written the same way as the new packages (theme-a11y, theme-cart, etc.) so they are not held to the same linting rules.

We will remove these ignores when these packages have been updated.