### PR TITLE
Duplicate object returned by getDefaultRequestConfig

### DIFF
--- a/packages/theme-cart/request.js
+++ b/packages/theme-cart/request.js
@@ -1,11 +1,13 @@
 function getDefaultRequestConfig() {
-  return {
-    credentials: 'same-origin',
-    headers: {
-      'X-Requested-With': 'XMLHttpRequest',
-      'Content-Type': 'application/json;'
-    }
-  };
+  return JSON.parse(
+    JSON.stringify({
+      credentials: 'same-origin',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/json;'
+      }
+    })
+  );
 }
 
 function fetchJSON(url, config) {


### PR DESCRIPTION
When Uglified, the object returned was being simplified to include "method: 'POST'", which was breaking GET request like "/cart.js".

Thanks @martinamarien!