### PR TITLE
Restore cookiesEnabled @shopify/theme-cart 

### DIFF
--- a/packages/theme-cart/README.md
+++ b/packages/theme-cart/README.md
@@ -199,3 +199,16 @@ cart.getShippingRates().then(rates => {
   console.log('Got shipping rates:', rates);
 });
 ```
+
+### cookiesEnabled()
+
+Browser cookies are required to use the cart. Returns true if the browser supports cookies.
+
+```js
+if (cookiesEnabled()) {
+  document.documentElement.className = document.documentElement.className.replace(
+    'supports-no-cookies',
+    'supports-cookies'
+  );
+}
+```

--- a/packages/theme-cart/theme-cart.js
+++ b/packages/theme-cart/theme-cart.js
@@ -185,3 +185,18 @@ export function clearNote() {
 export function getShippingRates() {
   return request.cartShippingRates();
 }
+
+/**
+ * Check if cookies are enabled in the browser
+ * @returns {Boolean}
+ */
+export function cookiesEnabled() {
+  var cookieEnabled = Boolean(window.navigator.cookieEnabled);
+
+  if (!cookieEnabled) {
+    document.cookie = 'cookieTest';
+    cookieEnabled = Boolean(document.cookie.indexOf('cookieTest') !== -1);
+  }
+
+  return cookieEnabled;
+}


### PR DESCRIPTION
Adding the unintentionally removed cookiesEnabled function from pre-1.0.0.  

Question: 1.0.0 removed the functionality to check if the browser supports localstorage, and if so save the cart state to localstorage.  Was that unintentionally removed as well?

Fixes #52 