### PR TITLE
Fix typo for a11y.accessibleLinks()

### DIFF
--- a/packages/theme-a11y/README.md
+++ b/packages/theme-a11y/README.md
@@ -23,13 +23,13 @@ These files make Theme A11y accessible via the `Shopify.theme.a11y` global varia
 
 ---
 
-### accessibleLinks(messages, targetLinks, prefix)
+### accessibleLinks(elements, options)
 
 Add a descriptive message to external links and links that open to a new window.
 
 - `elements` - Specific elements to be targeted
-- `options.messages`: Custom messages object to overwrite with keys: newWindow, external, newWindowExternal
+- `options.messages` - Custom messages object to overwrite with keys: newWindow, external, newWindowExternal
 - `options.messages.newWindow` - When the link opens in a new window (e.g. `target="_blank"`)
 - `options.messages.external` - When the link is to a different host domain.
 - `options.messages.newWindowExternal` - When the link is to a different host domain and opens in a new window.
-- `options.prefix`: Prefix to namespace "id" of the messages
+- `options.prefix` - Prefix to namespace "id" of the messages


### PR DESCRIPTION
Fixed a small typo in the read me file for `accessibleLinks()`