### PR TITLE
[BUGFIX] Retain all query params when changing variant

### DIFF
--- a/packages/theme-variants/variants.js
+++ b/packages/theme-variants/variants.js
@@ -177,7 +177,7 @@ export default class Variants {
     if (/variant=/.test(currentHref)) {
       newUrl = currentHref.replace(/(variant=)[^\&]+/, '$1' + variant.id)
     } else {
-      newUrl = currentHref.concat('&variant=').concat(variant.id)
+      newUrl = currentHref.concat('?&variant=').concat(variant.id)
     }
 
     window.history.replaceState({ path: newUrl }, '', newUrl)

--- a/packages/theme-variants/variants.js
+++ b/packages/theme-variants/variants.js
@@ -161,7 +161,8 @@ export default class Variants {
   }
 
   /**
-   * Update history state for product deeplinking
+   * Update history state for product deeplinking while still retaining the query
+   * params.
    *
    * @param {object} variant - Currently selected variant
    */
@@ -170,14 +171,16 @@ export default class Variants {
       return;
     }
 
-    var newurl =
-      window.location.protocol +
-      '//' +
-      window.location.host +
-      window.location.pathname +
-      '?variant=' +
-      variant.id;
-    window.history.replaceState({ path: newurl }, '', newurl);
+    var currentHref = window.location.href
+    var newUrl = ''
+
+    if (/variant=/.test(currentHref)) {
+      newUrl = currentHref.replace(/(variant=)[^\&]+/, '$1' + variant.id)
+    } else {
+      newUrl = currentHref.concat('&variant=').concat(variant.id)
+    }
+
+    window.history.replaceState({ path: newUrl }, '', newUrl)
   }
 
   /**

--- a/packages/theme-variants/variants.js
+++ b/packages/theme-variants/variants.js
@@ -177,7 +177,7 @@ export default class Variants {
     if (/variant=/.test(currentHref)) {
       newUrl = currentHref.replace(/(variant=)[^\&]+/, '$1' + variant.id)
     } else {
-      newUrl = currentHref.concat('?&variant=').concat(variant.id)
+      newUrl = currentHref.concat('?variant=').concat(variant.id)
     }
 
     window.history.replaceState({ path: newUrl }, '', newUrl)


### PR DESCRIPTION
The current code will strip out all query-params in the URL except the variant. This creates issue when custom theme requires to use the extra params Google analytics or other purposes.
The PR will either add `variant` param to the URL if it's not existed yet, or will replace the current `variant id` with the selected one.