### PR TITLE
Add getUrlWithVariant() method

### DIFF
--- a/packages/theme-product/README.md
+++ b/packages/theme-product/README.md
@@ -144,3 +144,12 @@ Find a matching variant using an array of option values and return it.
 ```javascript
 ['36', 'Black'];
 ```
+
+### getUrlWithVariant(url, variantId)
+
+Adds or replaces the `variant` query parameter on a given URL. Useful for updating the browser history with the current variant URL when users are switching variants on the product page.
+
+```javascript
+const newUrl = getUrlWithVariant(window.location.href, variant.id);
+window.history.replaceState({ path: newUrl }, '', newUrl);
+```

--- a/packages/theme-product/__tests__/theme-product.test.js
+++ b/packages/theme-product/__tests__/theme-product.test.js
@@ -3,11 +3,48 @@
  */
 import $ from 'jquery';
 import {
+  getUrlWithVariant,
   getVariantFromId,
   getVariantFromSerializedArray,
   getVariantFromOptionArray
 } from '../theme-product';
 import productJson from '../__fixtures__/product.json';
+
+describe('getUrlWithVariant()', () => {
+  test('is a function exported by theme-product.js', () => {
+    expect(typeof getUrlWithVariant).toBe('function');
+  });
+
+  test('adds the "variant" query parameter if it does not exist in the URL', () => {
+    expect(getUrlWithVariant('https://shop1.myshopify.com', 12345678)).toBe(
+      'https://shop1.myshopify.com?variant=12345678'
+    );
+  });
+
+  test('replaces the value of the "variant" query parameter if it does already exist in the URL', () => {
+    expect(
+      getUrlWithVariant(
+        'https://shop1.myshopify.com?variant=12345678',
+        87654321
+      )
+    ).toBe('https://shop1.myshopify.com?variant=87654321');
+  });
+
+  test('does not modify query parameters that do not have the "variant" key', () => {
+    expect(
+      getUrlWithVariant(
+        'https://shop1.myshopify.com?variant=12345678&id=12345678',
+        87654321
+      )
+    ).toBe('https://shop1.myshopify.com?variant=87654321&id=12345678');
+    expect(
+      getUrlWithVariant(
+        'https://shop1.myshopify.com?id=12345678&variant=12345678',
+        87654321
+      )
+    ).toBe('https://shop1.myshopify.com?id=12345678&variant=87654321');
+  });
+});
 
 describe('getVariantFromId()', () => {
   test('is a function exported by theme-product.js', () => {

--- a/packages/theme-product/theme-product.js
+++ b/packages/theme-product/theme-product.js
@@ -19,6 +19,21 @@ export function getVariantFromId(product, value) {
 }
 
 /**
+ * Returns a URL with a variant ID query parameter. Useful for updating window.history
+ * with a new URL based on the currently select product variant.
+ * @param {string} url - The URL you wish to append the variant ID to
+ * @param {number} id  - The variant ID you wish to append to the URL
+ * @returns {string} - The new url which includes the variant ID query parameter
+ */
+export function getUrlWithVariant(url, id) {
+  if (/variant=/.test(url)) {
+    return url.replace(/(variant=)[^&]+/, '$1' + id);
+  } else {
+    return url.concat('?variant=').concat(id);
+  }
+}
+
+/**
  * Convert the Object (with 'name' and 'value' keys) into an Array of values, then find a match & return the variant (as an Object)
  * @param {Object} product Product JSON object
  * @param {Object} collection Object with 'name' and 'value' keys (e.g. [{ name: "Size", value: "36" }, { name: "Color", value: "Black" }])


### PR DESCRIPTION
Based on work done by @pmkhoa in https://github.com/Shopify/theme-scripts/pull/71

Adds a new getUrlWithVariant() method which returns a url with the `variant` query parameter.