### PR TITLE
Replace ` with a single quote

### DIFF
--- a/packages/theme-currency/README.md
+++ b/packages/theme-currency/README.md
@@ -11,5 +11,5 @@ yarn add @shopify/theme-currency
 and then import the functions you wish to use through ES6 imports:
 
 ```
-import * as currency from '@shopify/theme-currency`;
+import * as currency from '@shopify/theme-currency';
 ```


### PR DESCRIPTION
When you copy / paste the import statement it turns out there is ` instead of a single quote. 