### PR TITLE
Update README for Element.matches() browser support - theme a11y

### DIFF
--- a/packages/theme-a11y/README.md
+++ b/packages/theme-a11y/README.md
@@ -25,7 +25,7 @@ These files make Theme A11y accessible via the `Shopify.theme.a11y` global varia
 
 ## Browser Support
 
-Theme A11y uses method not available to legacy browsers: `Element.matches()`. If you wish to support legacy browsers, make sure you add the following dependencies to your project:
+Theme A11y uses a method not available in legacy browsers: `Element.matches()`. If you wish to support legacy browsers, make sure you add the following dependencies to your project:
 
 ```
 yarn add element-matches

--- a/packages/theme-a11y/README.md
+++ b/packages/theme-a11y/README.md
@@ -23,6 +23,26 @@ These files make Theme A11y accessible via the `Shopify.theme.a11y` global varia
 
 ---
 
+## Browser Support
+
+Theme A11y uses method not available to legacy browsers: `Element.matches()`. If you wish to support legacy browsers, make sure you add the following dependencies to your project:
+
+```
+yarn add element-matches
+```
+
+and then import them before you import Theme A11y:
+
+```js
+// Only need to import these once
+import 'element-matches';
+
+// Import @shopify/theme-a11y anywhere you need it
+import * as a11y from '@shopify/theme-a11y';
+```
+
+## Methods
+
 ### accessibleLinks(elements, options)
 
 Add a descriptive message to external links and links that open to a new window.

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -53,8 +53,6 @@ export function focusHash(options) {
   var hash = window.location.hash;
   var element = document.getElementById(hash.slice(1));
 
-  polyfillMatches();
-
   // if we are to ignore this element, early return
   if (element && options.ignore && element.matches(options.ignore)) {
     return false;
@@ -80,8 +78,6 @@ export function bindInPageLinks(options) {
   var links = Array.prototype.slice.call(
     document.querySelectorAll('a[href^="#"]')
   );
-
-  polyfillMatches();
 
   return links.filter(function(link) {
     if (link.hash === '#' || link.hash === '') {
@@ -281,12 +277,4 @@ export function accessibleLinks(elements, options) {
   });
 
   generateHTML(messages);
-}
-
-function polyfillMatches() {
-  if (!Element.prototype.matches) {
-    Element.prototype.matches =
-      Element.prototype.msMatchesSelector ||
-      Element.prototype.webkitMatchesSelector;
-  }
 }

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -285,6 +285,8 @@ export function accessibleLinks(elements, options) {
 
 function polyfillMatches() {
   if (!Element.prototype.matches) {
-    Element.prototype.matches = Element.prototype.msMatchesSelector;
+    Element.prototype.matches =
+      Element.prototype.msMatchesSelector ||
+      Element.prototype.webkitMatchesSelector;
   }
 }

--- a/packages/theme-a11y/theme-a11y.js
+++ b/packages/theme-a11y/theme-a11y.js
@@ -53,6 +53,8 @@ export function focusHash(options) {
   var hash = window.location.hash;
   var element = document.getElementById(hash.slice(1));
 
+  polyfillMatches();
+
   // if we are to ignore this element, early return
   if (element && options.ignore && element.matches(options.ignore)) {
     return false;
@@ -78,6 +80,8 @@ export function bindInPageLinks(options) {
   var links = Array.prototype.slice.call(
     document.querySelectorAll('a[href^="#"]')
   );
+
+  polyfillMatches();
 
   return links.filter(function(link) {
     if (link.hash === '#' || link.hash === '') {
@@ -277,4 +281,10 @@ export function accessibleLinks(elements, options) {
   });
 
   generateHTML(messages);
+}
+
+function polyfillMatches() {
+  if (!Element.prototype.matches) {
+    Element.prototype.matches = Element.prototype.msMatchesSelector;
+  }
 }


### PR DESCRIPTION
### What are you trying to accomplish in this PR
Fixes https://github.com/Shopify/theme-scripts/issues/83

Some of the functions inside Theme A11y require to use `matches()` method. Specifically on IE, the method will prompt an error since it is not supported officially. We need to use `msMatchesSelector` instead.

[MDN polyfill](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill)

#### Expectation
We should not see the error again.

![image](https://user-images.githubusercontent.com/658169/54631490-7c053300-4a52-11e9-9c6d-07c73359f800.png)