### PR TITLE
Compatibility with product JSON pulled from liquid {{ json }} filter

### DIFF
--- a/packages/theme-product/__fixtures__/productFromLiquid.json
+++ b/packages/theme-product/__fixtures__/productFromLiquid.json
@@ -1,0 +1,44 @@
+{
+  "id": 520670707773,
+  "title": "Aircontact 75 + 10",
+  "vendor": "tauclothes",
+  "variants": [
+    {
+      "id": 6908023078973,
+      "product_id": 520670707773,
+      "title": "36 / Black",
+      "option1": "36",
+      "option2": "Black",
+      "options": ["36", "Black"]
+    },
+    {
+      "id": 6908198682685,
+      "product_id": 520790016061,
+      "title": "37 / Black",
+      "option1": "37",
+      "option2": "Black",
+      "options": ["37", "Black"]
+    },
+    {
+      "id": 6908198649917,
+      "product_id": 520790016061,
+      "title": "38 / Black",
+      "option1": "38",
+      "option2": "Black",
+      "options": ["38", "Black"]
+    }
+  ],
+  "options": ["Size", "Color"],
+  "images": [
+    {
+      "id": 2004809744445,
+      "product_id": 520670707773,
+      "variant_ids": []
+    }
+  ],
+  "image": {
+    "id": 2004809744445,
+    "product_id": 520670707773,
+    "variant_ids": []
+  }
+}

--- a/packages/theme-product/__tests__/theme-product.test.js
+++ b/packages/theme-product/__tests__/theme-product.test.js
@@ -11,6 +11,7 @@ import {
   getVariantFromOptionArray
 } from '../theme-product';
 import productJson from '../__fixtures__/product.json';
+import productFromLiquidJson from '../__fixtures__/productFromLiquid.json';
 
 describe("getProductJson()", () => {
   test("get product by handle", () => {
@@ -131,6 +132,13 @@ describe('getVariantFromSerializedArray()', () => {
       $('form').serializeArray()
     );
     expect(variant).toEqual(productJson.variants[0]);
+
+    const variantFromLiquid = getVariantFromSerializedArray(
+      productFromLiquidJson,
+      $('form').serializeArray()
+    );
+    expect(variantFromLiquid).toEqual(productJson.variants[0]);
+
   });
 
   test('returns null when a match is not found', () => {
@@ -153,6 +161,12 @@ describe('getVariantFromSerializedArray()', () => {
       $('form').serializeArray()
     );
     expect(variant).toEqual(null);
+
+    const variantFromLiquid = getVariantFromSerializedArray(
+      productJson,
+      $('form').serializeArray()
+    );
+    expect(variantFromLiquid).toEqual(null);
   });
 });
 

--- a/packages/theme-product/theme-product.js
+++ b/packages/theme-product/theme-product.js
@@ -76,7 +76,8 @@ function _createOptionArrayFromOptionCollection(product, collection) {
 
   collection.forEach(function(option) {
     for (var i = 0; i < product.options.length; i++) {
-      if (product.options[i].name.toLowerCase() === option.name.toLowerCase()) {
+      var name = product.options[i].name || product.options[i];
+      if (name.toLowerCase() === option.name.toLowerCase()) {
         optionArray[i] = option.value;
         break;
       }


### PR DESCRIPTION
This change manages the difference between product JSON from Liquid `{{ product | json }}` and product JSON from `/products/${product.handle}.js`

JSON from Liquid stores the name at `product.options[i]`
JSON fetched from the API stores the name at `product.options[i].name`

Here's an example of JSON from the same product loaded with Liquid vs JS:

<img width="2179" alt="liquid-json" src="https://user-images.githubusercontent.com/299520/67531702-8f2b5180-f678-11e9-9d66-4083a17515ea.png">

The [theme-product-form docs](https://github.com/Shopify/theme-scripts/blob/master/packages/theme-product-form/README.md) specify that you should be able to use JSON pulled from Liquid:

```
// Fetch the product data from the .js endpoint because it includes
// more data than the .json endpoint. Alternatively, you could inline the output
// of {{ product | json }} inside a <script> tag, with the downside that the
// data can never be cached by the browser.
```

I can't say why this discrepancy exists, but pulling in the JSON from Liquid seems like a common use case.