### PR TITLE
Fixing country and zone default bugs in addressForm.js

### DIFF
--- a/packages/theme-addresses/addressForm.js
+++ b/packages/theme-addresses/addressForm.js
@@ -169,7 +169,11 @@ function populateZones(formElements, country) {
   zoneSelect.innerHTML = duplicatedZoneSelect.innerHTML;
 
   if (zoneSelect.dataset.default) {
-    var defaultValue = zoneSelect.dataset.default.length > 2 ? zoneCodeKey[zoneSelect.dataset.default] : zoneSelect.dataset.default;
+    var defaultValue = zoneSelect.dataset.default;
+
+    if (defaultValue > 2 && zoneCodeKey.hasOwnProperty(defaultValue)) {
+      defaultValue = zoneCodeKey[zoneSelect.dataset.default];
+    }
 
     zoneSelect.value = defaultValue;
   }

--- a/packages/theme-addresses/addressForm.js
+++ b/packages/theme-addresses/addressForm.js
@@ -130,7 +130,11 @@ function populateCountries(formElements, countries) {
   countrySelect.innerHTML = duplicatedCountrySelect.innerHTML;
 
   if (countrySelect.dataset.default) {
-    var defaultValue = countrySelect.dataset.default.length > 2 ? countryCodeKey[countrySelect.dataset.default] : countrySelect.dataset.default;
+    var defaultValue = countrySelect.dataset.default;
+
+    if (defaultValue > 2 && countryCodeKey.hasOwnProperty(defaultValue)) {
+      defaultValue = countryCodeKey[defaultValue];
+    }
 
     countrySelect.value = defaultValue;
   }
@@ -172,7 +176,7 @@ function populateZones(formElements, country) {
     var defaultValue = zoneSelect.dataset.default;
 
     if (defaultValue > 2 && zoneCodeKey.hasOwnProperty(defaultValue)) {
-      defaultValue = zoneCodeKey[zoneSelect.dataset.default];
+      defaultValue = zoneCodeKey[defaultValue];
     }
 
     zoneSelect.value = defaultValue;

--- a/packages/theme-addresses/addressForm.js
+++ b/packages/theme-addresses/addressForm.js
@@ -128,7 +128,11 @@ function populateCountries(formElements, countries) {
   countrySelect.innerHTML = duplicatedCountrySelect.innerHTML;
 
   if (countrySelect.dataset.default) {
-    countrySelect.value = countrySelect.dataset.default;
+    var defaultValue = countrySelect.dataset.default.length > 2 ? countries.find((country) => {
+      return country.name === countrySelect.dataset.default;
+    }) : countrySelect.dataset.default;
+
+    countrySelect.value = defaultValue.code;
   }
 }
 
@@ -163,7 +167,15 @@ function populateZones(formElements, country) {
   zoneSelect.innerHTML = duplicatedZoneSelect.innerHTML;
 
   if (zoneSelect.dataset.default) {
-    zoneSelect.value = zoneSelect.dataset.default;
+    var defaultValue = zoneSelect.dataset.default.length > 2 ? country.zones.find((zone) => {
+      return zone.name === zoneSelect.dataset.default;
+    }) : zoneSelect.dataset.default;
+
+    if (typeof defaultValue === 'object') {
+      defaultValue = defaultValue.code;
+    }
+
+    zoneSelect.value = defaultValue;
   }
 }
 

--- a/packages/theme-addresses/addressForm.js
+++ b/packages/theme-addresses/addressForm.js
@@ -117,22 +117,22 @@ function setLabels(formElements, country) {
 function populateCountries(formElements, countries) {
   var countrySelect = formElements.country.input;
   var duplicatedCountrySelect = countrySelect.cloneNode(true);
+  var countryCodeKey = [];
 
   countries.forEach(function(country) {
     var optionElement = document.createElement('option');
     optionElement.value = country.code;
     optionElement.textContent = country.name;
     duplicatedCountrySelect.appendChild(optionElement);
+    countryCodeKey[country.name] = country.code;
   });
 
   countrySelect.innerHTML = duplicatedCountrySelect.innerHTML;
 
   if (countrySelect.dataset.default) {
-    var defaultValue = countrySelect.dataset.default.length > 2 ? countries.find(function(country) {
-      return country.name === countrySelect.dataset.default;
-    }) : countrySelect.dataset.default;
+    var defaultValue = countrySelect.dataset.default.length > 2 ? countryCodeKey[countrySelect.dataset.default] : countrySelect.dataset.default;
 
-    countrySelect.value = defaultValue.code;
+    countrySelect.value = defaultValue;
   }
 }
 
@@ -156,24 +156,20 @@ function populateZones(formElements, country) {
   var zoneSelect = zoneEl.input;
   var duplicatedZoneSelect = zoneSelect.cloneNode(true);
   duplicatedZoneSelect.innerHTML = '';
+  var zoneCodeKey = [];
 
   country.zones.forEach(function(zone) {
     var optionElement = document.createElement('option');
     optionElement.value = zone.code;
     optionElement.textContent = zone.name;
     duplicatedZoneSelect.appendChild(optionElement);
+    zoneCodeKey[zone.name] = zone.code;
   });
 
   zoneSelect.innerHTML = duplicatedZoneSelect.innerHTML;
 
   if (zoneSelect.dataset.default) {
-    var defaultValue = zoneSelect.dataset.default.length > 2 ? country.zones.find(function(zone) {
-      return zone.name === zoneSelect.dataset.default;
-    }) : zoneSelect.dataset.default;
-
-    if (typeof defaultValue === 'object') {
-      defaultValue = defaultValue.code;
-    }
+    var defaultValue = zoneSelect.dataset.default.length > 2 ? zoneCodeKey[zoneSelect.dataset.default] : zoneSelect.dataset.default;
 
     zoneSelect.value = defaultValue;
   }

--- a/packages/theme-addresses/addressForm.js
+++ b/packages/theme-addresses/addressForm.js
@@ -128,7 +128,7 @@ function populateCountries(formElements, countries) {
   countrySelect.innerHTML = duplicatedCountrySelect.innerHTML;
 
   if (countrySelect.dataset.default) {
-    var defaultValue = countrySelect.dataset.default.length > 2 ? countries.find((country) => {
+    var defaultValue = countrySelect.dataset.default.length > 2 ? countries.find(function(country) {
       return country.name === countrySelect.dataset.default;
     }) : countrySelect.dataset.default;
 
@@ -167,7 +167,7 @@ function populateZones(formElements, country) {
   zoneSelect.innerHTML = duplicatedZoneSelect.innerHTML;
 
   if (zoneSelect.dataset.default) {
-    var defaultValue = zoneSelect.dataset.default.length > 2 ? country.zones.find((zone) => {
+    var defaultValue = zoneSelect.dataset.default.length > 2 ? country.zones.find(function(zone) {
       return zone.name === zoneSelect.dataset.default;
     }) : zoneSelect.dataset.default;
 


### PR DESCRIPTION
This pull request reconciles the fact that address forms use 2-letter codes for country and zone as their option values, while Shopify's Liquid {{ form.country }} and {{ form.province }} return the full name. (updated to use ES5)