### PR TITLE
fix addItem and empty options

### DIFF
--- a/packages/theme-product-form/__tests__/theme-product-form.test.js
+++ b/packages/theme-product-form/__tests__/theme-product-form.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-const {getVariantFromSerializedArray} = require('@shopify/theme-product');
+const {getVariantFromSerializedArray} = require('../../theme-product/theme-product');
 const {getUrlWithVariant, ProductForm} = require('../theme-product-form');
 const productJSON = require('../__fixtures__/product-object.json');
 
@@ -18,6 +18,12 @@ const defaultProperties = [
   {name: 'Hidden', value: 'something'},
   {name: 'Subscribe', value: 'true'}
 ];
+
+const serializedProperties = {
+  [defaultProperties[0].name]: defaultProperties[0].value,
+  [defaultProperties[1].name]: defaultProperties[1].value,
+  [defaultProperties[2].name]: defaultProperties[2].value,
+};
 
 beforeEach(() => {
   document.body.innerHTML = `
@@ -50,14 +56,14 @@ function expectFormEventDataset(
   {
     options = defaultOptions,
     quantity = defaultQuantity,
-    properties = defaultProperties
+    properties = serializedProperties
   }
 ) {
   expect(event.dataset.options).toMatchObject(options);
   expect(event.dataset.variant).toMatchObject(
     getVariantFromSerializedArray(productJSON, options)
   );
-  expect(event.dataset.properties.length).toBe(properties.length);
+  expect(Object.entries(event.dataset.properties).length).toBe(Object.entries(properties).length);
   expect(event.dataset.properties).toMatchObject(properties);
   expect(event.dataset.quantity).toBe(quantity);
 }
@@ -150,7 +156,7 @@ describe('ProductForm()', () => {
     const element = document.getElementById('form');
     const productForm = new ProductForm(element, productJSON);
 
-    expect(productForm.propertyInputs.length).toBe(defaultProperties.length);
+    expect(productForm.propertyInputs.length).toBe(Object.entries(defaultProperties).length);
   });
 
   test('calls the method assigned to the onOptionChange option when the value of an option input changes', () => {
@@ -208,20 +214,15 @@ describe('ProductForm()', () => {
     const config = {
       onPropertyChange: jest.fn()
     };
-    const properties = [
-      {name: 'Message', value: 'doh'},
-      {name: 'Hidden', value: 'something'},
-      {name: 'Subscribe', value: 'true'}
-    ];
 
     // eslint-disable-next-line no-unused-vars
     const productForm = new ProductForm(element, productJSON, config);
 
-    propertyElement.value = properties[0].value;
+    propertyElement.value = defaultProperties[0].value;
     propertyElement.dispatchEvent(changeEvent);
 
     expect(config.onPropertyChange).toHaveBeenCalledWith(changeEvent);
-    expectFormEventDataset(changeEvent, {properties});
+    expectFormEventDataset(changeEvent, {serializedProperties});
   });
 
   test('calls the method assigned to the onFormSubmit option when the form is submitted', () => {
@@ -302,11 +303,11 @@ describe('ProductForm.variant()', () => {
 });
 
 describe('ProductForm.properties()', () => {
-  test('returns a collection of objects containing the name and value of properties', () => {
+  test('returns a collection object containing the name and value of properties', () => {
     const element = document.getElementById('form');
     const productForm = new ProductForm(element, productJSON);
 
-    expect(productForm.properties()).toMatchObject(defaultProperties);
+    expect(productForm.properties()).toMatchObject(serializedProperties);
   });
 });
 

--- a/packages/theme-product-form/__tests__/theme-product-form.test.js
+++ b/packages/theme-product-form/__tests__/theme-product-form.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-const {getVariantFromSerializedArray} = require('../../theme-product/theme-product');
+const {getVariantFromSerializedArray} = require('@shopify/theme-product');
 const {getUrlWithVariant, ProductForm} = require('../theme-product-form');
 const productJSON = require('../__fixtures__/product-object.json');
 
@@ -19,11 +19,13 @@ const defaultProperties = [
   {name: 'Subscribe', value: 'true'}
 ];
 
-const serializedProperties = {
-  [defaultProperties[0].name]: defaultProperties[0].value,
-  [defaultProperties[1].name]: defaultProperties[1].value,
-  [defaultProperties[2].name]: defaultProperties[2].value,
-};
+const serializedProperties = defaultProperties.reduce(
+  (properties, property) => {
+    properties[property.name] = property.value;
+    return properties;
+  },
+  {}
+);
 
 beforeEach(() => {
   document.body.innerHTML = `

--- a/packages/theme-product-form/theme-product-form.js
+++ b/packages/theme-product-form/theme-product-form.js
@@ -1,5 +1,5 @@
 import Listeners from './listeners';
-import { getVariantFromSerializedArray } from '../theme-product/theme-product';
+import { getVariantFromSerializedArray } from '@shopify/theme-product';
 
 var selectors = {
   idInput: '[name="id"]',

--- a/packages/theme-product-form/theme-product-form.js
+++ b/packages/theme-product-form/theme-product-form.js
@@ -5,7 +5,7 @@ var selectors = {
   idInput: '[name="id"]',
   optionInput: '[name^="options"]',
   quantityInput: '[name="quantity"]',
-  propertyInput: '[name^="properties"]'
+  propertyInput: '[name^="properties"]',
 };
 
 // Public Methods
@@ -83,7 +83,7 @@ ProductForm.prototype.destroy = function() {
  * @returns {Array} An array of option values
  */
 ProductForm.prototype.options = function() {
-  return _serializeInputValues(this.optionInputs, function(item) {
+  return _serializeOptionValues(this.optionInputs, function(item) {
     var regex = /(?:^(options\[))(.*?)(?:\])/;
     item.name = regex.exec(item.name)[2]; // Use just the value between 'options[' and ']'
     return item;
@@ -107,11 +107,15 @@ ProductForm.prototype.variant = function() {
  * @returns {Array} Collection of objects with name and value keys
  */
 ProductForm.prototype.properties = function() {
-  return _serializeInputValues(this.propertyInputs, function(item) {
+  var properties = _serializePropertyValues(this.propertyInputs, function(
+    propertyName
+  ) {
     var regex = /(?:^(properties\[))(.*?)(?:\])/;
-    item.name = regex.exec(item.name)[2]; // Use just the value between 'properties[' and ']'
-    return item;
+    var name = regex.exec(propertyName)[2]; // Use just the value between 'properties[' and ']'
+    return name;
   });
+
+  return Object.entries(properties).length === 0 ? null : properties;
 };
 
 /**
@@ -180,11 +184,11 @@ ProductForm.prototype._getProductFormEventData = function() {
     options: this.options(),
     variant: this.variant(),
     properties: this.properties(),
-    quantity: this.quantity()
+    quantity: this.quantity(),
   };
 };
 
-function _serializeInputValues(inputs, transform) {
+function _serializeOptionValues(inputs, transform) {
   return inputs.reduce(function(options, input) {
     if (
       input.checked || // If input is a checked (means type radio or checkbox)
@@ -195,6 +199,19 @@ function _serializeInputValues(inputs, transform) {
 
     return options;
   }, []);
+}
+
+function _serializePropertyValues(inputs, transform) {
+  return inputs.reduce(function(properties, input) {
+    if (
+      input.checked || // If input is a checked (means type radio or checkbox)
+      (input.type !== 'radio' && input.type !== 'checkbox') // Or if its any other type of input
+    ) {
+      properties[transform(input.name)] = input.value;
+    }
+
+    return properties;
+  }, {});
 }
 
 function _validateProductObject(product) {

--- a/packages/theme-product-form/theme-product-form.js
+++ b/packages/theme-product-form/theme-product-form.js
@@ -1,11 +1,11 @@
 import Listeners from './listeners';
-import { getVariantFromSerializedArray } from '@shopify/theme-product';
+import { getVariantFromSerializedArray } from '../theme-product/theme-product';
 
 var selectors = {
   idInput: '[name="id"]',
   optionInput: '[name^="options"]',
   quantityInput: '[name="quantity"]',
-  propertyInput: '[name^="properties"]',
+  propertyInput: '[name^="properties"]'
 };
 
 // Public Methods
@@ -184,7 +184,7 @@ ProductForm.prototype._getProductFormEventData = function() {
     options: this.options(),
     variant: this.variant(),
     properties: this.properties(),
-    quantity: this.quantity(),
+    quantity: this.quantity()
   };
 };
 

--- a/packages/theme-product/__tests__/theme-product.test.js
+++ b/packages/theme-product/__tests__/theme-product.test.js
@@ -88,7 +88,7 @@ describe('getVariantFromSerializedArray()', () => {
     ];
 
     expect(() => {
-      getVariantFromSerializedArray(productJson, []);
+      getVariantFromSerializedArray(productJson, {});
     }).toThrow();
 
     expect(() => {

--- a/packages/theme-product/theme-product.js
+++ b/packages/theme-product/theme-product.js
@@ -112,7 +112,7 @@ function _validateSerializedArray(collection) {
   }
 
   if (collection.length === 0) {
-    throw new Error(collection + ' is empty.');
+    return [];
   }
 
   if (collection[0].hasOwnProperty('name')) {


### PR DESCRIPTION
### Purpose 
Fix properties by converting it to an object instead of an array for `addItem`. `/cart/add.js` accepts a property object.

Fix the `onSubmit` validation for options. It was throwing an "is empty" error for products with no selectors / variants.

 ### Unknown
Not sure if I did the tests properly 😬 