### PR TITLE
[theme-cart] Add item from Product Form

### DIFF
--- a/packages/theme-cart/README.md
+++ b/packages/theme-cart/README.md
@@ -10,7 +10,7 @@ This library is compatible with the following browsers:
 | ------ | ---- | ------- | --- | ----- | ------ |
 | ✓      | ✓    | ✓       | ✕*  | ✓     | ✓      |
 
-* The script is no longer compatible with IE11 starting v4.0.0. The latest version that supports IE11 is v2.0.2.
+* The script is no longer compatible with IE11 starting v4.0.0. The last version that supports IE11 is v2.0.2.
 
 ## Getting Started
 
@@ -94,7 +94,7 @@ cart.getItem(key).then(item => {
 
 Adds an item to your cart. If no quantity is specified, 1 item is added. Returns a promise which fulfills with the matching [line item](https://help.shopify.com/en/themes/liquid/objects/line_item).
 
-> ⚠️ If the quantity specified is more then what is available, the promise will reject and the cart state will remain unchanged
+> ⚠️ If the quantity specified is more than what is available, the promise will be rejected and the cart state will remain unchanged
 
 ```js
 cart.addItem(id, { quantity, properties }).then(item => {
@@ -109,7 +109,7 @@ cart.addItem(id, { quantity, properties }).then(item => {
 
 Adds an item to your cart from a product form. The form must contain an input with `name="id"`. If there is no input named `quantity`, 1 item is added. Returns a promise which fulfills with the matching [line item](https://help.shopify.com/en/themes/liquid/objects/line_item).
 
-> ⚠️ If the quantity specified is more then what is available, the promise will reject and the cart state will remain unchanged
+> ⚠️ If the quantity specified is more than what is available, the promise will be rejected and the cart state will remain unchanged
 
 ```js
 cart.addItemFromForm(form).then(item => {

--- a/packages/theme-cart/README.md
+++ b/packages/theme-cart/README.md
@@ -2,6 +2,16 @@
 
 Theme Cart is a tiny library (<1kb min+gzip) that facilitates requests to [Shopify's Cart API](https://help.shopify.com/en/themes/development/getting-started/using-ajax-api) and makes it easier to manage cart state.
 
+## Browser Support
+
+This library is compatible with the following browsers:
+
+| Chrome | Edge | Firefox | IE  | Opera | Safari |
+| ------ | ---- | ------- | --- | ----- | ------ |
+| ✓      | ✓    | ✓       | ✕*  | ✓     | ✓      |
+
+* The script is no longer compatible with IE11 starting v3.0.0. The latest version that supports IE11 is v2.0.2.
+
 ## Getting Started
 
 Theme Scripts can be used in any theme project. To take advantage of semantic versioning and easy updates, we recommend using NPM or Yarn to include them in your project:
@@ -90,6 +100,21 @@ Adds an item to your cart. If no quantity is specified, 1 item is added. Returns
 cart.addItem(id, { quantity, properties }).then(item => {
   console.log(
     `An item with a quantity of ${quantity} was added to your cart:`,
+    item
+  );
+});
+```
+
+### addItemFromForm([form](https://developer.mozilla.org/en/docs/Web/API/HTMLFormElement)) })
+
+Adds an item to your cart from a product form. The form must contain an input with `name="id"`. If there is no input named `quantity`, 1 item is added. Returns a promise which fulfills with the matching [line item](https://help.shopify.com/en/themes/liquid/objects/line_item).
+
+> ⚠️ If the quantity specified is more then what is available, the promise will reject and the cart state will remain unchanged
+
+```js
+cart.addItemFromForm(form).then(item => {
+  console.log(
+    `An item was added to your cart:`,
     item
   );
 });

--- a/packages/theme-cart/README.md
+++ b/packages/theme-cart/README.md
@@ -10,7 +10,7 @@ This library is compatible with the following browsers:
 | ------ | ---- | ------- | --- | ----- | ------ |
 | ✓      | ✓    | ✓       | ✕*  | ✓     | ✓      |
 
-* The script is no longer compatible with IE11 starting v3.0.0. The latest version that supports IE11 is v2.0.2.
+* The script is no longer compatible with IE11 starting v4.0.0. The latest version that supports IE11 is v2.0.2.
 
 ## Getting Started
 

--- a/packages/theme-cart/__tests__/theme-cart.test.js
+++ b/packages/theme-cart/__tests__/theme-cart.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 require('isomorphic-fetch');
 
 const fetchMock = require('fetch-mock');
@@ -36,6 +40,18 @@ function mockCartAdd(url, options) {
 
   // Simulate /cart/add.js 422 error object when request quantity is unavailable
   if (typeof body.quantity !== 'undefined' && body.quantity > 9) {
+    // eslint-disable-next-line no-throw-literal
+    throw {status: 422};
+  }
+
+  return populatedState.items[0];
+}
+
+function mockCartAddFromForm(url, options) {
+  const body = options.body;
+
+  // Simulate /cart/add.js 422 error object when request quantity is unavailable
+  if (typeof body.get('quantity') !== 'undefined' && body.get('quantity') > 9) {
     // eslint-disable-next-line no-throw-literal
     throw {status: 422};
   }
@@ -184,6 +200,62 @@ describe('addItem()', () => {
     const id = item.id;
 
     await expect(cart.addItem(id)).resolves.toMatchObject(item);
+  });
+});
+
+describe('addItemFromForm()', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="valid-form">
+        <select name="id">
+          <option selected="selected" value="32497200136297">small</option>
+          <option disabled="disabled" value="32497200169065">large</option>
+        </select>
+        <input type="number" name="quantity" value="3" />
+        <input type="text" name="properties[Message]" value="derp" />
+      </form>
+      <form id="empty-form"></form>`;
+
+    fetchMock.mock('/cart/add.js', mockCartAddFromForm);
+  });
+
+  afterEach(fetchMock.restore);
+
+  test('throws an error if parameter is not a valid form', () => {
+    const validForm = document.getElementById('valid-form');
+
+    expect(() => cart.addItemFromForm(validForm)).not.toThrowError();
+    expect(() => cart.addItemFromForm().toThrowError(TypeError));
+    expect(() => cart.addItemFromForm({}).toThrowError(TypeError));
+    expect(() => cart.addItemFromForm('123456')).toThrowError(TypeError);
+  });
+
+  test('throws an error if form is missing id or quantity', () => {
+    const emptyForm = document.getElementById('empty-form');
+    expect(() => cart.addItemFromForm(emptyForm)).toThrowError(Error);
+  });
+
+  test('throws an error if either id or quantity is invalid', () => {
+    const validForm = document.getElementById('valid-form');
+
+    const invalidForm = document.createElement('form');
+    invalidForm.innerHTML = validForm.innerHTML.replace('32497200136297', 'abcde');
+    expect(() => cart.addItemFromForm(invalidForm)).toThrowError(TypeError);
+
+    invalidForm.innerHTML = validForm.innerHTML.replace('name="quantity" value="3"', 'name="quantity" value="de"');
+    expect(() => cart.addItemFromForm(invalidForm)).toThrowError(TypeError);
+  });
+
+  test('returns a promise', () => {
+    const validForm = document.getElementById('valid-form');
+    expect(cart.addItemFromForm(validForm).then).toBeDefined();
+  });
+
+  test('fulfills with the line item which was added to the cart', async () => {
+    const validForm = document.getElementById('valid-form');
+    const item = require('../__fixtures__/cart-populated.json').items[0];
+
+    await expect(cart.addItemFromForm(validForm)).resolves.toMatchObject(item);
   });
 });
 

--- a/packages/theme-cart/__tests__/theme-cart.test.js
+++ b/packages/theme-cart/__tests__/theme-cart.test.js
@@ -226,7 +226,7 @@ describe('addItemFromForm()', () => {
 
   afterEach(fetchMock.restore);
 
-  test('throws an error if parameter is not a valid form', () => {
+  test('throws an error if argument is not a valid form', () => {
     const validForm = document.getElementById('valid-form');
 
     expect(() => cart.addItemFromForm(validForm)).not.toThrowError();

--- a/packages/theme-cart/__tests__/theme-cart.test.js
+++ b/packages/theme-cart/__tests__/theme-cart.test.js
@@ -214,6 +214,9 @@ describe('addItemFromForm()', () => {
         <input type="number" name="quantity" value="3" />
         <input type="text" name="properties[Message]" value="derp" />
       </form>
+      <form id="invalid-form">
+        <input type="text" name="id" value="not a number" />
+      </form>
       <form id="empty-form"></form>`;
 
     fetchMock.mock('/cart/add.js', mockCartAddFromForm);
@@ -230,19 +233,11 @@ describe('addItemFromForm()', () => {
     expect(() => cart.addItemFromForm('123456')).toThrowError(TypeError);
   });
 
-  test('throws an error if form is missing id or quantity', () => {
+  test('throws an error if id is empty or NaN', () => {
     const emptyForm = document.getElementById('empty-form');
     expect(() => cart.addItemFromForm(emptyForm)).toThrowError(Error);
-  });
 
-  test('throws an error if either id or quantity is invalid', () => {
-    const validForm = document.getElementById('valid-form');
-
-    const invalidForm = document.createElement('form');
-    invalidForm.innerHTML = validForm.innerHTML.replace('32497200136297', 'abcde');
-    expect(() => cart.addItemFromForm(invalidForm)).toThrowError(TypeError);
-
-    invalidForm.innerHTML = validForm.innerHTML.replace('name="quantity" value="3"', 'name="quantity" value="de"');
+    const invalidForm = document.getElementById('invalid-form');
     expect(() => cart.addItemFromForm(invalidForm)).toThrowError(TypeError);
   });
 

--- a/packages/theme-cart/__tests__/theme-cart.test.js
+++ b/packages/theme-cart/__tests__/theme-cart.test.js
@@ -217,7 +217,9 @@ describe('addItemFromForm()', () => {
       <form id="invalid-form">
         <input type="text" name="id" value="not a number" />
       </form>
-      <form id="empty-form"></form>`;
+      <form id="no-id-form">
+        <input type="text" name="description" value="this form has no id" />
+      </form>`;
 
     fetchMock.mock('/cart/add.js', mockCartAddFromForm);
   });
@@ -234,8 +236,8 @@ describe('addItemFromForm()', () => {
   });
 
   test('throws an error if id is empty or NaN', () => {
-    const emptyForm = document.getElementById('empty-form');
-    expect(() => cart.addItemFromForm(emptyForm)).toThrowError(Error);
+    const noIdForm = document.getElementById('no-id-form');
+    expect(() => cart.addItemFromForm(noIdForm)).toThrowError(Error);
 
     const invalidForm = document.getElementById('invalid-form');
     expect(() => cart.addItemFromForm(invalidForm)).toThrowError(TypeError);

--- a/packages/theme-cart/request.js
+++ b/packages/theme-cart/request.js
@@ -36,6 +36,14 @@ export function cartAdd(id, quantity, properties) {
   return fetchJSON('/cart/add.js', config);
 }
 
+export function cartAddFromForm(formData) {
+  var config = {};
+  config.method = 'POST';
+  config.body = formData;
+
+  return fetchJSON('/cart/add.js', config);
+}
+
 export function cartChange(line, options) {
   var config = getDefaultRequestConfig();
 

--- a/packages/theme-cart/request.js
+++ b/packages/theme-cart/request.js
@@ -37,7 +37,9 @@ export function cartAdd(id, quantity, properties) {
 }
 
 export function cartAddFromForm(formData) {
-  var config = {};
+  var config = getDefaultRequestConfig();
+  delete config.headers['Content-Type'];
+
   config.method = 'POST';
   config.body = formData;
 

--- a/packages/theme-cart/theme-cart.js
+++ b/packages/theme-cart/theme-cart.js
@@ -85,18 +85,14 @@ export function addItem(id, options) {
 
 /**
  * Add a new line item to the cart from a product form
- * @param {object} form The product form element
+ * @param {object} form DOM element which is equal to the <form> node
  * @returns {Promise} Resolves with the line item object (See response of cart/add.js https://help.shopify.com/en/themes/development/getting-started/using-ajax-api#add-to-cart)
  */
 export function addItemFromForm(form) {
   validate.form(form);
 
   var formData = new FormData(form);
-  if (!formData.get('quantity')) {
-    formData.append('quantity', 1);
-  }
-
-  validate.formData(formData);
+  validate.id(parseInt(formData.get('id'), 10));
 
   return request.cartAddFromForm(formData);
 }

--- a/packages/theme-cart/theme-cart.js
+++ b/packages/theme-cart/theme-cart.js
@@ -84,6 +84,24 @@ export function addItem(id, options) {
 }
 
 /**
+ * Add a new line item to the cart from a product form
+ * @param {object} form The product form element
+ * @returns {Promise} Resolves with the line item object (See response of cart/add.js https://help.shopify.com/en/themes/development/getting-started/using-ajax-api#add-to-cart)
+ */
+export function addItemFromForm(form) {
+  validate.form(form);
+
+  var formData = new FormData(form);
+  if (!formData.get('quantity')) {
+    formData.append('quantity', 1);
+  }
+
+  validate.formData(formData);
+
+  return request.cartAddFromForm(formData);
+}
+
+/**
  * Changes the quantity and/or properties of an existing line item.
  * @param {string} key The unique key of the line item (https://help.shopify.com/en/themes/liquid/objects/line_item#line_item-key)
  * @param {object} options Optional values to pass to /cart/add.js

--- a/packages/theme-cart/validate.js
+++ b/packages/theme-cart/validate.js
@@ -32,21 +32,6 @@ export function form(form) {
   }
 }
 
-export function formData(formData) {
-  if (!(formData instanceof FormData)) {
-    throw new TypeError('Theme Cart: Form must be a FormData object');
-  }
-
-  if (typeof formData.get('id') === 'undefined' || typeof formData.get('quantity') === 'undefined') {
-    throw new Error(
-      'Theme Cart: Form must contain id and quantity data'
-    );
-  }
-
-  id(parseInt(formData.get('id'), 10));
-  quantity(parseInt(formData.get('quantity'), 10));
-}
-
 export function options(options) {
   if (typeof options !== 'object') {
     throw new TypeError('Theme Cart: Options must be an object');

--- a/packages/theme-cart/validate.js
+++ b/packages/theme-cart/validate.js
@@ -7,7 +7,7 @@ export function key(key) {
 }
 
 export function quantity(quantity) {
-  if (typeof quantity !== 'number') {
+  if (typeof quantity !== 'number' || isNaN(quantity)) {
     throw new TypeError(
       'Theme Cart: An object which specifies a quantity or properties value is required'
     );
@@ -15,7 +15,7 @@ export function quantity(quantity) {
 }
 
 export function id(id) {
-  if (typeof id !== 'number') {
+  if (typeof id !== 'number' || isNaN(id)) {
     throw new TypeError('Theme Cart: Variant ID must be a number');
   }
 }
@@ -24,6 +24,27 @@ export function properties(properties) {
   if (typeof properties !== 'object') {
     throw new TypeError('Theme Cart: Properties must be an object');
   }
+}
+
+export function form(form) {
+  if (!(form instanceof HTMLFormElement)) {
+    throw new TypeError('Theme Cart: Form must be an instance of HTMLFormElement');
+  }
+}
+
+export function formData(formData) {
+  if (!(formData instanceof FormData)) {
+    throw new TypeError('Theme Cart: Form must be a FormData object');
+  }
+
+  if (typeof formData.get('id') === 'undefined' || typeof formData.get('quantity') === 'undefined') {
+    throw new Error(
+      'Theme Cart: Form must contain id and quantity data'
+    );
+  }
+
+  id(parseInt(formData.get('id'), 10));
+  quantity(parseInt(formData.get('quantity'), 10));
 }
 
 export function options(options) {


### PR DESCRIPTION
### Purpose
Adds `addItemFromForm` method to `theme-cart`. 
Fix #93.

### Why this is needed?
Submitting `FormData` requests is necessary to support file uploads when adding items to cart by AJAX. Otherwise, the browser will replace the `File` object with a invalid string such as `C:\fakepath\filename.png`. 

### Approach
#### addItemFromForm
The `addItemFromForm` accepts a `HTMLFormElement` and passes it to a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) constructor.

It then validates its `id` as a number and calls `request.cartAddFromForm()` by passing this `FormData` element.

#### cartAddFromForm
The `request.cartAddFromForm()` method will `POST` the data to `cart/add.js`. There are two key differences from the original here:
1. It wont send the body data as `JSON` containing `id`, `quantity` and `properties` but as the `FormData` object itself.
2. The request header WON'T have a `Content-Type` as [the browser must set the correct boundary itself](https://muffinman.io/uploading-files-using-fetch-multipart-form-data/).

### Tophatting 🎩 
On a theme compatible with `addItemToForm`
- [ ] Does it work with regular products with no variants and no line item properties?
- [ ] Does it work with no quantity selector on the form?
- [ ] Does it add the right quantity from the quantity selector input?
- [ ] Does it add the correct variant to the cart on products with multiple variants ?
- [ ] Does it add products with custom line item properties?
- [ ] Does it uploads files on products with `input type="file"` custom line item properties?

### Notes / question to reviewers
IE11 has some compatibility issues with `FormData`. For instance, it not support `FormData.get(key)` method.

Is there an alternative to `formData.get('id')` when validating the form ID that maintains compatibility with IE11?