### PR TITLE
Only set variant id if variant exists

### DIFF
--- a/packages/theme-product-form/theme-product-form.js
+++ b/packages/theme-product-form/theme-product-form.js
@@ -148,7 +148,9 @@ ProductForm.prototype._setIdInputValue = function(value) {
 ProductForm.prototype._onSubmit = function(options, event) {
   event.dataset = this._getProductFormEventData();
 
-  this._setIdInputValue(event.dataset.variant.id);
+  if (event.dataset.variant) {
+    this._setIdInputValue(event.dataset.variant.id);
+  }
 
   if (options.onFormSubmit) {
     options.onFormSubmit(event);


### PR DESCRIPTION
### Purpose
Currently, if you try to add a variant to the cart that does not exist, a console error is outputted because it's trying to access a value on a null variable. 

### Approach 
I have changed it to only set `_setIdInputValue` if the value exists.  

### Testing 
Run `yarn link` from this branch 
From the theme repo, open the branch and run `yarn link "@shopify/theme-product-form"` 
Test the different states: Add to cart, unavailable and sold out. 