### PR TITLE
Fix Module for Bad Packages

### DIFF
--- a/packages/theme-currency/package.json
+++ b/packages/theme-currency/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "A library that helps with managing currencies in Shopify Themes",
   "main": "dist/currency.cjs.js",
-  "modules": "dist/currency.es5.js",
+  "module": "currency.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Shopify/theme-scripts.git"

--- a/packages/theme-images/package.json
+++ b/packages/theme-images/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "A library that helps with basic image operations within Shopify Themes",
   "main": "dist/images.cjs.js",
-  "modules": "dist/images.es5.js",
+  "module": "images.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Shopify/theme-scripts.git"

--- a/packages/theme-rte/package.json
+++ b/packages/theme-rte/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "A library that helps developers work with the RTE sections in Shopify Themes",
   "main": "dist/rte.cjs.js",
-  "modules": "dist/rte.es5.js",
+  "module": "rte.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Shopify/theme-scripts.git"


### PR DESCRIPTION
Fix the module property in package.json for the three packages that haven't yet been updated: theme-currency, theme-images, and theme-rte. 

This involves changing `modules: dist/*.es5.js` to `module: *.js` to match the other packages.