### PR TITLE
Add support for WEBP images

### DIFF
--- a/packages/theme-images/images.js
+++ b/packages/theme-images/images.js
@@ -65,7 +65,7 @@ export function getSizedImageUrl(src, size) {
     return removeProtocol(src);
   }
 
-  const match = src.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
+  const match = src.match(/\.(jpeg\.webp|jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
 
   if (match) {
     const prefix = src.split(match[0]);


### PR DESCRIPTION
Add support for `.jpeg.webp` images in the `getSizedImageUrl` function.

Shopify outputs images in WEBP format which need to be able to have sizes added, for example this real Shopify URL: `https://cdn.shopify.com/s/files/1/0896/0640/products/IMG_20190622_130045_clipped_rev_1.jpeg.webp?v=1582896583`