### PR TITLE
Fix reference to product options

### DIFF
--- a/packages/theme-product/theme-product.js
+++ b/packages/theme-product/theme-product.js
@@ -76,7 +76,8 @@ function _createOptionArrayFromOptionCollection(product, collection) {
 
   collection.forEach(function(option) {
     for (var i = 0; i < product.options.length; i++) {
-      if (product.options[i].name.toLowerCase() === option.name.toLowerCase()) {
+      const optionName = product.options[i].name ?? product.options[i];
+      if (optionName.toLowerCase() === option.name.toLowerCase()) {
         optionArray[i] = option.value;
         break;
       }


### PR DESCRIPTION
There is a discrepancy between JSON returned from `fetch('/products/PRODUCT_HANDLE.js')` and `{{ product | json }}`.

In first one, options property contains array of objects:
```
options: [
   {name: "Option1", position: 1, values: Array(4)},
   {name: "Option2", position: 2, values: Array(4)},
   {name: "Option3", position: 3, values: Array(3)},
]
```
The latter returns options property that contains direct option names:
```
options: [
   'Option1',
   'Option2',
   'Option3',
]
```

To prevent errors being thrown while using this in conjunction with theme-product-form.js on JSON returned with liquid tag, we need to do a quick check on what type of options property does current product object contain.